### PR TITLE
fix: タイポ、f-string欠落、未定義変数、不正な型注釈を修正

### DIFF
--- a/junos-update
+++ b/junos-update
@@ -160,7 +160,7 @@ def copy(hostname, dev):
     # copy
     if args.dryrun:
         print(
-            "dryrun: scp(cheksum:%s) %s %s:%s"
+            "dryrun: scp(checksum:%s) %s %s:%s"
             % (
                 config.get(hostname, "hashalgo"),
                 get_model_file(hostname, dev.facts["model"]),
@@ -250,7 +250,7 @@ def clear_reboot(dev) -> bool:
         try:
             rpc = dev.rpc.clear_reboot({"format": "text"})
             str = etree.tostring(rpc, encoding="unicode")
-            logger.debug("{rpc=} {str=}")
+            logger.debug(f"{rpc=} {str=}")
             if (
                 str.find("No shutdown/reboot scheduled.") >= 0
                 or str.find("Terminating...") >= 0
@@ -588,7 +588,7 @@ def check_running_package(hostname, dev):
     return ret
 
 
-def compare_version(left : str, right : str) -> None or int:
+def compare_version(left: str, right: str) -> int | None:
     """compare version left and right
 
     :param left: version left string, ex 18.4R3-S9.2
@@ -711,7 +711,7 @@ def get_pending_version(hostname, dev) -> str:
                         else:
                             pending = None
             except Exception as e:
-                print(err)
+                print(e)
                 sys.exit(1)
         else:
             print("Unknown personality:", dev.facts)
@@ -723,7 +723,7 @@ def get_pending_version(hostname, dev) -> str:
         print("Show version failure caused by RpcTimeoutError:", e)
         sys.exit(1)
     except Exception as e:
-        print(err)
+        print(e)
         sys.exit(1)
     return pending
 
@@ -739,7 +739,7 @@ def get_planning_version(hostname, dev) -> str:
     return planning
 
 
-def get_reboot_infomation(hostname, dev):
+def get_reboot_information(hostname, dev):
     """show system reboot
     :return: halt requested by exadmin at Sun Dec 19 08:30:00 2021
              shutdown requested by exadmin at Sun Dec 12 08:30:00 2021
@@ -812,7 +812,7 @@ def show_version(hostname, dev):
     # remote package check
     remote = check_remote_package(hostname, dev)
 
-    rebooting = get_reboot_infomation(hostname, dev)
+    rebooting = get_reboot_information(hostname, dev)
     if rebooting is not None:
         print(f"  - {rebooting}")
 
@@ -986,7 +986,7 @@ def main():
 
     logger.debug(f"{args=}")
     logger.debug(f"{args.specialhosts=}")
-    logger.debug("f{targets=}")
+    logger.debug(f"{targets=}")
 
     for host in targets:
         logger.debug(f"{host=}")


### PR DESCRIPTION
## Summary
- **#14** `cheksum` → `checksum`、`get_reboot_infomation` → `get_reboot_information`（呼び出し側も修正）
- **#8** f-stringプレフィックス `f` の欠落を修正（`clear_reboot()` 253行目、`main()` 989行目）
- **#7** `get_pending_version()` の `except` ブロックで未定義の `err` → キャッチ変数 `e` に修正（714行目、726行目）
- **#12** `compare_version()` の型注釈 `-> None or int`（常に `int` と評価される）→ `-> int | None` に修正

Closes #14, Closes #8, Closes #7, Closes #12

## Test plan
- [ ] `--dryrun` で各機能が正常に動作すること
- [ ] `--showversion` で `get_reboot_information` が正しく呼ばれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)