### PR TITLE
fix: 空レシピ検出漏れとdev.open()二重呼出しを修正

### DIFF
--- a/junos-update
+++ b/junos-update
@@ -52,10 +52,9 @@ def read_config():
     global config
     config = configparser.ConfigParser(allow_no_value=True)
     config.read(args.recipe)
-    if args.debug:
-        if len(config.sections()) == 0:
-            print(args.recipe, "is empty")
-            return True
+    if len(config.sections()) == 0:
+        print(args.recipe, "is empty")
+        return True
     for section in config.sections():
         if config.has_option(section, "host"):
             host = config.get(section, "host")
@@ -823,11 +822,6 @@ def show_version(hostname, dev):
 
 def reboot(hostname: str, dev, reboot_dt: datetime.datetime):
     logger.debug(f"{reboot_dt=}")
-    try:
-        dev.open()
-    except ConnectError as err:
-        logger.error(f"{err=}")
-        return 1
     try:
         rpc = dev.rpc.get_reboot_information({"format": "text"})
     except ConnectError as err:


### PR DESCRIPTION
## Summary
- **#11** `read_config()` の空セクションチェックが `if args.debug:` 内にネストされており、`--debug` なしで空レシピを指定すると無言終了していた。チェックを外に出して常に検出されるよう修正
- **#10** `reboot()` 内の `dev.open()` を削除。`main()` の `connect()` で既に `open()` 済みのため二重呼出しだった

Closes #11, Closes #10

## Test plan
- [ ] 空の .ini ファイルを `--recipe` に指定して `--debug` なしで実行し、エラーメッセージが表示されること
- [ ] `--rebootat` オプションで正常にリブートスケジュールが設定されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)