### PR TITLE
fix: logging.ini 未同梱問題を修正

### DIFF
--- a/junos-update
+++ b/junos-update
@@ -39,8 +39,16 @@ import re
 import sys
 from logging import getLogger, config
 import logging
+import os
 
-config.fileConfig("logging.ini")
+if os.path.isfile("logging.ini"):
+    config.fileConfig("logging.ini")
+else:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        handlers=[logging.StreamHandler(sys.stdout)]
+    )
 logger = logging.getLogger(__name__)
 
 config = None

--- a/logging.ini
+++ b/logging.ini
@@ -1,0 +1,33 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=logFileHandler,consoleHandler
+
+[formatters]
+keys=logFileFormatter,consoleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=logFileHandler,consoleHandler
+
+[handler_logFileHandler]
+class=handlers.TimedRotatingFileHandler
+#level=DEBUG
+level=INFO
+formatter=logFileFormatter
+args=('logger.log',"midnight", 1, 10)
+
+[handler_consoleHandler]
+class=StreamHandler
+#level=INFO
+level=DEBUG
+formatter=consoleFormatter
+args=(sys.stdout,)
+
+[formatter_logFileFormatter]
+#format=%(filename)s %(asctime)s [%(levelname)s] %(name)s %(funcName)s %(message)s
+format=%(asctime)s [%(levelname)s] %(name)s %(funcName)s %(message)s
+
+[formatter_consoleFormatter]
+format=[%(levelname)s] %(funcName)s - %(message)s


### PR DESCRIPTION
## Summary
- **#9** `logging.ini` をリポジトリに追加し、クローン直後でもスクリプトが動作するようにした
- `logging.ini` が存在しない場合は `logging.basicConfig()` でフォールバックし、`FileNotFoundError` でクラッシュしないようにした

Closes #9

## Test plan
- [ ] `logging.ini` がある状態で従来通り動作すること
- [ ] `logging.ini` を削除した状態でもクラッシュせず動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)