### PR TITLE
refactor: マルチスレッド化の下準備リファクタリング

### DIFF
--- a/junos-update
+++ b/junos-update
@@ -37,6 +37,7 @@ import configparser
 import datetime
 import re
 import sys
+import threading
 from logging import getLogger, config
 import logging
 import os
@@ -52,8 +53,9 @@ else:
 logger = logging.getLogger(__name__)
 
 config = None
+config_lock = threading.Lock()
 args = None
-version = "0.1"
+version = "0.2"
 
 
 def read_config():
@@ -236,16 +238,16 @@ def rollback(hostname, dev):
                 return True
         except RpcError as e:
             print("request system software rollback failure caused by RpcError:", e)
-            sys.exit(1)
+            return True
         except RpcTimeoutError as e:
             print(
                 "request system software rollback failure caused by RpcTimeoutError:",
                 e,
             )
-            sys.exit(1)
+            return True
         except Exception as e:
             print(e)
-            sys.exit(1)
+            return True
     return False
 
 
@@ -270,13 +272,13 @@ def clear_reboot(dev) -> bool:
                 return True
         except RpcError as e:
             logger.error(f"Clear reboot failure caused by RpcError: {e}")
-            sys.exit(1)
+            return True
         except RpcTimeoutError as e:
             logger.error(f"Clear reboot failure caused by RpcTimeoutError: {e}")
-            sys.exit(1)
+            return True
         except Exception as e:
             logger.error(e)
-            sys.exit(1)
+            return True
     return False
 
 
@@ -350,10 +352,10 @@ def install(hostname, dev):
                 return True
         except ValueError as e:
             print("wrong rescue action", e)
-            sys.exit(1)
+            return True
         except Exception as e:
             print(e)
-            sys.exit(1)
+            return True
 
     # request system software add ...
     if args.dryrun:
@@ -401,34 +403,36 @@ def get_model_file(hostname, model):
     try:
         return config.get(hostname, model.lower() + ".file")
     except Exception as e:
-        print(config.read(args.recipe), e)
-        sys.exit(1)
+        logger.error(f"{hostname}: {model.lower()}.file not found in recipe: {e}")
+        raise
 
 
 def get_model_hash(hostname, model):
     try:
         return config.get(hostname, model.lower() + ".hash")
     except Exception as e:
-        print(config.read(args.recipe), e)
-        sys.exit(1)
+        logger.error(f"{hostname}: {model.lower()}.hash not found in recipe: {e}")
+        raise
 
 
 def get_hashcache(hostname, file):
-    if config.has_section(hostname) is False:
-        return None
-    if config.has_option(hostname, file + "hashcache"):
-        hashcache = config.get(hostname, file + "hashcache")
-    else:
-        hashcache = None
-    return hashcache
+    with config_lock:
+        if config.has_section(hostname) is False:
+            return None
+        if config.has_option(hostname, file + "hashcache"):
+            hashcache = config.get(hostname, file + "hashcache")
+        else:
+            hashcache = None
+        return hashcache
 
 
 def set_hashcache(hostname, file, value):
     global config
-    if config.has_section(hostname) is False:
-        # "localhost"
-        config.add_section(hostname)
-    config.set(hostname, file + "hashcache", value)
+    with config_lock:
+        if config.has_section(hostname) is False:
+            # "localhost"
+            config.add_section(hostname)
+        config.set(hostname, file + "hashcache", value)
 
 
 def check_local_package(hostname, dev):
@@ -719,19 +723,19 @@ def get_pending_version(hostname, dev) -> str:
                             pending = None
             except Exception as e:
                 print(e)
-                sys.exit(1)
+                return None
         else:
             print("Unknown personality:", dev.facts)
-            return True
+            return None
     except RpcError as e:
         print("Show version failure caused by RpcError:", e)
-        sys.exit(1)
+        return None
     except RpcTimeoutError as e:
         print("Show version failure caused by RpcTimeoutError:", e)
-        sys.exit(1)
+        return None
     except Exception as e:
         print(e)
-        sys.exit(1)
+        return None
     return pending
 
 
@@ -757,13 +761,13 @@ def get_reboot_information(hostname, dev):
         rpc = dev.rpc.get_reboot_information({"format": "text"})
     except RpcError as e:
         logger.error("Show version failure caused by RpcError:", e)
-        sys.exit(1)
+        return None
     except RpcTimeoutError as e:
         logger.error("Show version failure caused by RpcTimeoutError:", e)
-        sys.exit(1)
+        return None
     except Exception as e:
         logger.error(e)
-        sys.exit(1)
+        return None
     xml_str = etree.tostring(rpc, encoding="unicode")
     if args.debug:
         print(xml_str)
@@ -883,6 +887,74 @@ def yymmddhhmm_type(dt_str: str) -> datetime.datetime:
         )
 
 
+def process_host(hostname: str) -> int:
+    """単一ホストの処理。戻り値: 0=成功, 非0=エラー"""
+    logger.debug(f"{hostname=}")
+    logger.debug(f"{datetime.datetime.now()=}")
+    print(f"# {hostname}")
+
+    err, dev = connect(hostname)
+    if err or dev is None:
+        return 1
+
+    try:
+        if (
+            args.list_format is None
+            and args.copy is False
+            and args.install is False
+            and args.update is False
+            and args.showversion is False
+            and args.rollback is False
+            and args.rebootat is None
+        ) or args.debug:
+            pprint(dev.facts)
+        if args.list_format is not None:
+            list_remote_path(hostname, dev)
+        # copy or update
+        if args.copy:
+            err = copy(hostname, dev)
+            if err:
+                return 1
+        # rollback
+        if args.rollback:
+            pending = get_pending_version(hostname, dev)
+            print(f"rollback: pending version is {pending}")
+            if pending is None:
+                print("rollback: skip")
+            else:
+                err = rollback(hostname, dev)
+                if err:
+                    return 1
+                else:
+                    if args.dryrun is False:
+                        print("rollback: successful")
+        # install or update
+        if args.install or args.update:
+            err = install(hostname, dev)
+            if err:
+                return 1
+        # show version
+        if args.showversion:
+            err = show_version(hostname, dev)
+            if err:
+                return 1
+        # reboot at
+        if args.rebootat:
+            ret = reboot(hostname, dev, args.rebootat)
+            if ret:
+                return ret
+        return 0
+    except Exception as e:
+        logger.error(f"{hostname}: {e}")
+        return 1
+    finally:
+        try:
+            dev.close()
+        except (ConnectClosedError, Exception):
+            pass
+        print("")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="automatically detect Juniper models and automatically update JUNOS packages",
@@ -991,68 +1063,9 @@ def main():
     logger.debug(f"{targets=}")
 
     for host in targets:
-        logger.debug(f"{host=}")
-        logger.debug(f"{datetime.datetime.now()=}")
-        print(f"# {host}")
-
-        err, dev = connect(host)
-        if err or dev is None:
-            sys.exit(1)
-        if (
-            args.list_format is None
-            and args.copy is False
-            and args.install is False
-            and args.update is False
-            and args.showversion is False
-            and args.rollback is False
-            and args.rebootat is None
-        ) or args.debug:
-            pprint(dev.facts)
-        if args.list_format is not None:
-            list_remote_path(host, dev)
-        # copy or update
-        err = None
-        if args.copy:
-            err = copy(host, dev)
-            if err:
-                sys.exit(1)
-        # rollback
-        if args.rollback:
-            pending = get_pending_version(host, dev)
-            print(f"rollback: pending version is {pending}")
-            if pending is None:
-                print("rollback: skip")
-            else:
-                err = rollback(host, dev)
-                if err:
-                    sys.exit(err)
-                else:
-                    if args.dryrun is False:
-                        print("rollback: successful")
-        # install or update
-        if args.install or args.update:
-            err = install(host, dev)
-            if err:
-                sys.exit(1)
-        # show version
-        if args.showversion:
-            err = show_version(host, dev)
-            if err:
-                sys.exit(1)
-        # reboot at
-        if args.rebootat:
-            err = reboot(host, dev, args.rebootat)
-            if err:
-                sys.exit(err)
-        # close
-        try:
-            dev.close()
-        except ConnectClosedError as e:
-            print("Connection unexpectedly closed", e)
-        except Exception as e:
-            print(e)
-
-        print("")
+        ret = process_host(host)
+        if ret != 0:
+            sys.exit(ret)
 
     logger.debug("end")
 


### PR DESCRIPTION
## Summary
- 各関数内の `sys.exit()` 約17箇所を `return` / `raise` に変更し、関数が呼び出し元に制御を返すように修正
- `main()` のホストループ本体を `process_host()` 関数として切り出し、`ThreadPoolExecutor` に渡せる構造に整備
- `get/set_hashcache()` に `threading.Lock` を導入し、将来のマルチスレッド実行時のconfig書き込み競合を防止
- `get_pending_version()` の `return True` バグ（`-> str` 関数が `True` を返す型不整合）も修正
- バージョンを 0.1 → 0.2 に更新

Closes #17

## Test plan
- [x] `python3 -m py_compile junos-update` — 構文チェックOK
- [x] `./junos-update -V` — `junos-update 0.2` 表示OK
- [ ] `./junos-update --dryrun hostname` — ドライラン確認（VPN接続時）
- [ ] 実機での `--showversion`, `--copy`, `--install` 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)