### PR TITLE
ci: GitHub Actionsとpytestによるテスト基盤を構築

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Syntax check
+        run: python3 -m py_compile junos-update
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 junos-eznc
 looseversion
+pytest
+pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,63 @@
+import importlib.util
+import importlib.machinery
+import argparse
+import configparser
+from pathlib import Path
+import pytest
+
+# プロジェクトルートの junos-update スクリプトのパス
+SCRIPT_PATH = str(Path(__file__).resolve().parent.parent / "junos-update")
+
+
+@pytest.fixture
+def junos_update():
+    """junos-update スクリプトをモジュールとしてインポート"""
+    loader = importlib.machinery.SourceFileLoader("junos_update", SCRIPT_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "junos_update", SCRIPT_PATH, loader=loader
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mock_args(junos_update):
+    """テスト用の args グローバル変数を設定"""
+    junos_update.args = argparse.Namespace(
+        debug=False,
+        dryrun=False,
+        force=False,
+        copy=False,
+        install=False,
+        update=False,
+        showversion=False,
+        rollback=False,
+        rebootat=None,
+        list_format=None,
+        recipe="junos.ini",
+    )
+    return junos_update.args
+
+
+@pytest.fixture
+def mock_config(junos_update):
+    """テスト用の config グローバル変数を設定"""
+    cfg = configparser.ConfigParser(allow_no_value=True)
+    cfg.read_dict(
+        {
+            "DEFAULT": {
+                "id": "testuser",
+                "pw": "testpass",
+                "sshkey": "id_ed25519",
+                "port": "830",
+                "hashalgo": "md5",
+                "rpath": "/var/tmp",
+                "ex2300-24t.file": "junos-arm-32-22.4R3-S6.5.tgz",
+                "ex2300-24t.hash": "abc123def456",
+            },
+            "test-host": {"host": "192.0.2.1"},
+        }
+    )
+    junos_update.config = cfg
+    return cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,139 @@
+"""設定読込・モデル取得・ハッシュキャッシュのテスト"""
+
+import configparser
+import threading
+
+import pytest
+
+
+class TestReadConfig:
+    """read_config() のテスト"""
+
+    def test_valid_recipe(self, junos_update, mock_args, tmp_path):
+        """正常なINIファイルを読み込める"""
+        recipe = tmp_path / "test.ini"
+        recipe.write_text(
+            "[DEFAULT]\n"
+            "id = testuser\n"
+            "port = 830\n"
+            "\n"
+            "[host1.example.jp]\n"
+            "\n"
+            "[host2.example.jp]\n"
+            "host = 192.0.2.1\n"
+        )
+        junos_update.args.recipe = str(recipe)
+        result = junos_update.read_config()
+        assert result is False
+        assert junos_update.config.has_section("host1.example.jp")
+        assert junos_update.config.has_section("host2.example.jp")
+
+    def test_empty_recipe(self, junos_update, mock_args, tmp_path):
+        """空のINIファイルはエラー（True）を返す"""
+        recipe = tmp_path / "empty.ini"
+        recipe.write_text("")
+        junos_update.args.recipe = str(recipe)
+        result = junos_update.read_config()
+        assert result is True
+
+    def test_host_default_to_section_name(self, junos_update, mock_args, tmp_path):
+        """hostキー省略時にセクション名がhostとして設定される"""
+        recipe = tmp_path / "test.ini"
+        recipe.write_text(
+            "[DEFAULT]\nid = testuser\nport = 830\n\n"
+            "[rt1.example.jp]\n"
+        )
+        junos_update.args.recipe = str(recipe)
+        junos_update.read_config()
+        assert junos_update.config.get("rt1.example.jp", "host") == "rt1.example.jp"
+
+    def test_host_override(self, junos_update, mock_args, tmp_path):
+        """hostキー指定時はその値が使われる"""
+        recipe = tmp_path / "test.ini"
+        recipe.write_text(
+            "[DEFAULT]\nid = testuser\nport = 830\n\n"
+            "[rt2.example.jp]\n"
+            "host = 192.0.2.1\n"
+        )
+        junos_update.args.recipe = str(recipe)
+        junos_update.read_config()
+        assert junos_update.config.get("rt2.example.jp", "host") == "192.0.2.1"
+
+
+class TestGetModelFile:
+    """get_model_file() のテスト"""
+
+    def test_found(self, junos_update, mock_config):
+        result = junos_update.get_model_file("test-host", "EX2300-24T")
+        assert result == "junos-arm-32-22.4R3-S6.5.tgz"
+
+    def test_not_found(self, junos_update, mock_config):
+        """存在しないモデルは例外を raise"""
+        with pytest.raises(configparser.NoOptionError):
+            junos_update.get_model_file("test-host", "UNKNOWN_MODEL")
+
+    def test_case_insensitive(self, junos_update, mock_config):
+        """モデル名は小文字に変換される"""
+        result = junos_update.get_model_file("test-host", "ex2300-24t")
+        assert result == "junos-arm-32-22.4R3-S6.5.tgz"
+
+
+class TestGetModelHash:
+    """get_model_hash() のテスト"""
+
+    def test_found(self, junos_update, mock_config):
+        result = junos_update.get_model_hash("test-host", "EX2300-24T")
+        assert result == "abc123def456"
+
+    def test_not_found(self, junos_update, mock_config):
+        """存在しないモデルは例外を raise"""
+        with pytest.raises(configparser.NoOptionError):
+            junos_update.get_model_hash("test-host", "UNKNOWN_MODEL")
+
+
+class TestHashcache:
+    """get_hashcache() / set_hashcache() のテスト"""
+
+    def test_set_and_get(self, junos_update, mock_config):
+        junos_update.set_hashcache("test-host", "testfile.tgz", "hash123")
+        result = junos_update.get_hashcache("test-host", "testfile.tgz")
+        assert result == "hash123"
+
+    def test_get_nonexistent_section(self, junos_update, mock_config):
+        """存在しないセクションは None を返す"""
+        result = junos_update.get_hashcache("nonexistent-host", "file.tgz")
+        assert result is None
+
+    def test_get_nonexistent_option(self, junos_update, mock_config):
+        """存在しないオプションは None を返す"""
+        result = junos_update.get_hashcache("test-host", "nofile.tgz")
+        assert result is None
+
+    def test_set_creates_section(self, junos_update, mock_config):
+        """存在しないセクションは自動作成される"""
+        junos_update.set_hashcache("new-host", "file.tgz", "hash456")
+        result = junos_update.get_hashcache("new-host", "file.tgz")
+        assert result == "hash456"
+
+    def test_thread_safety(self, junos_update, mock_config):
+        """複数スレッドからの同時アクセスでデータが壊れない"""
+        errors = []
+
+        def worker(host_id):
+            try:
+                host = f"thread-host-{host_id}"
+                for i in range(50):
+                    junos_update.set_hashcache(host, "file.tgz", f"hash-{host_id}-{i}")
+                    val = junos_update.get_hashcache(host, "file.tgz")
+                    if val is None:
+                        errors.append(f"{host}: got None")
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread safety errors: {errors}"

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,87 @@
+"""connect() のモックテスト"""
+
+from unittest.mock import patch, MagicMock
+
+from jnpr.junos.exception import (
+    ConnectAuthError,
+    ConnectClosedError,
+    ConnectRefusedError,
+    ConnectTimeoutError,
+    ConnectUnknownHostError,
+)
+
+
+class TestConnect:
+    """connect() の接続テスト"""
+
+    def test_success(self, junos_update, mock_args, mock_config):
+        """正常接続"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is False
+            assert dev is mock_dev
+            mock_dev.open.assert_called_once()
+
+    def test_auth_error(self, junos_update, mock_args, mock_config):
+        """認証エラー"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+            mock_dev.open.side_effect = ConnectAuthError(mock_dev)
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is True
+            assert dev is None
+
+    def test_timeout_error(self, junos_update, mock_args, mock_config):
+        """接続タイムアウト"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+            mock_dev.open.side_effect = ConnectTimeoutError(mock_dev)
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is True
+            assert dev is None
+
+    def test_refused_error(self, junos_update, mock_args, mock_config):
+        """接続拒否"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+            mock_dev.open.side_effect = ConnectRefusedError(mock_dev)
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is True
+            assert dev is None
+
+    def test_unknown_host_error(self, junos_update, mock_args, mock_config):
+        """不明なホスト"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+            mock_dev.open.side_effect = ConnectUnknownHostError(mock_dev)
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is True
+            assert dev is None
+
+    def test_generic_exception(self, junos_update, mock_args, mock_config):
+        """その他の例外"""
+        with patch.object(junos_update, "Device") as MockDevice:
+            mock_dev = MagicMock()
+            MockDevice.return_value = mock_dev
+            mock_dev.open.side_effect = Exception("unexpected error")
+
+            err, dev = junos_update.connect("test-host")
+
+            assert err is True
+            assert dev is None

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -1,0 +1,105 @@
+"""process_host() の統合テスト"""
+
+import configparser
+from unittest.mock import patch, MagicMock, call
+
+from jnpr.junos.exception import ConnectClosedError
+
+
+class TestProcessHost:
+    """process_host() のテスト"""
+
+    def test_connect_fail(self, junos_update, mock_args, mock_config):
+        """接続失敗時に 1 を返す"""
+        with patch.object(junos_update, "connect", return_value=(True, None)):
+            result = junos_update.process_host("test-host")
+            assert result == 1
+
+    def test_default_action(self, junos_update, mock_args, mock_config):
+        """オプションなし → pprint(facts) して 0 を返す"""
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T", "hostname": "test"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            result = junos_update.process_host("test-host")
+            assert result == 0
+            mock_dev.close.assert_called_once()
+
+    def test_copy_success(self, junos_update, mock_args, mock_config):
+        """--copy 成功時に 0 を返す"""
+        junos_update.args.copy = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(junos_update, "copy", return_value=False):
+                result = junos_update.process_host("test-host")
+                assert result == 0
+
+    def test_copy_failure(self, junos_update, mock_args, mock_config):
+        """--copy 失敗時に 1 を返す"""
+        junos_update.args.copy = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(junos_update, "copy", return_value=True):
+                result = junos_update.process_host("test-host")
+                assert result == 1
+
+    def test_exception_caught(self, junos_update, mock_args, mock_config):
+        """get_model_file等の例外が try/except でキャッチされ 1 を返す"""
+        junos_update.args.copy = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(
+                junos_update, "copy",
+                side_effect=configparser.NoOptionError("unknown.file", "test-host"),
+            ):
+                result = junos_update.process_host("test-host")
+                assert result == 1
+
+    def test_dev_close_always_called(self, junos_update, mock_args, mock_config):
+        """成功時でも dev.close() が呼ばれる"""
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            junos_update.process_host("test-host")
+            mock_dev.close.assert_called_once()
+
+    def test_dev_close_on_error(self, junos_update, mock_args, mock_config):
+        """エラー時でも dev.close() が呼ばれる"""
+        junos_update.args.copy = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(junos_update, "copy", return_value=True):
+                junos_update.process_host("test-host")
+                mock_dev.close.assert_called_once()
+
+    def test_dev_close_already_closed(self, junos_update, mock_args, mock_config):
+        """dev.close() で ConnectClosedError が出ても無視される"""
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        mock_dev.close.side_effect = ConnectClosedError(mock_dev)
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            result = junos_update.process_host("test-host")
+            assert result == 0
+
+    def test_showversion(self, junos_update, mock_args, mock_config):
+        """--showversion 成功時に 0 を返す"""
+        junos_update.args.showversion = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(junos_update, "show_version", return_value=False):
+                result = junos_update.process_host("test-host")
+                assert result == 0
+
+    def test_install_success(self, junos_update, mock_args, mock_config):
+        """--install 成功時に 0 を返す"""
+        junos_update.args.install = True
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(junos_update, "connect", return_value=(False, mock_dev)):
+            with patch.object(junos_update, "install", return_value=False):
+                result = junos_update.process_host("test-host")
+                assert result == 0

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,83 @@
+"""バージョン関連関数のテスト"""
+
+import argparse
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestCompareVersion:
+    """compare_version() のテスト"""
+
+    def test_greater(self, junos_update, mock_args):
+        assert junos_update.compare_version("22.4R3-S6", "22.4R3-S5") == 1
+
+    def test_less(self, junos_update, mock_args):
+        assert junos_update.compare_version("18.4R3-S9", "18.4R3-S10") == -1
+
+    def test_equal(self, junos_update, mock_args):
+        assert junos_update.compare_version("22.4R3-S6", "22.4R3-S6") == 0
+
+    def test_none_left(self, junos_update, mock_args):
+        assert junos_update.compare_version(None, "22.4R3-S6") is None
+
+    def test_none_right(self, junos_update, mock_args):
+        assert junos_update.compare_version("22.4R3-S6", None) is None
+
+    def test_both_none(self, junos_update, mock_args):
+        assert junos_update.compare_version(None, None) is None
+
+    def test_major_version_diff(self, junos_update, mock_args):
+        assert junos_update.compare_version("22.4R3-S6", "18.4R3-S10") == 1
+
+    def test_minor_version_diff(self, junos_update, mock_args):
+        assert junos_update.compare_version("22.2R1", "22.4R1") == -1
+
+
+class TestYymmddhhmmType:
+    """yymmddhhmm_type() のテスト"""
+
+    def test_valid(self, junos_update):
+        result = junos_update.yymmddhhmm_type("2501020304")
+        assert result == datetime.datetime(2025, 1, 2, 3, 4)
+
+    def test_year_end(self, junos_update):
+        result = junos_update.yymmddhhmm_type("2512311959")
+        assert result == datetime.datetime(2025, 12, 31, 19, 59)
+
+    def test_invalid_format(self, junos_update):
+        with pytest.raises(argparse.ArgumentTypeError):
+            junos_update.yymmddhhmm_type("invalid")
+
+    def test_empty_string(self, junos_update):
+        with pytest.raises(argparse.ArgumentTypeError):
+            junos_update.yymmddhhmm_type("")
+
+
+class TestGetPlanningVersion:
+    """get_planning_version() のテスト"""
+
+    def test_normal(self, junos_update, mock_args, mock_config):
+        dev = MagicMock()
+        dev.facts = {"model": "EX2300-24T"}
+        result = junos_update.get_planning_version("test-host", dev)
+        assert result == "22.4R3-S6.5"
+
+    def test_different_format(self, junos_update, mock_args, mock_config):
+        """SRX系のファイル名からもバージョン抽出できる"""
+        mock_config.set("DEFAULT", "srx345.file", "junos-srxsme-15.1X49-D240.tgz")
+        mock_config.set("DEFAULT", "srx345.hash", "dummy")
+        dev = MagicMock()
+        dev.facts = {"model": "SRX345"}
+        result = junos_update.get_planning_version("test-host", dev)
+        assert result == "15.1X49-D240"
+
+    def test_no_match(self, junos_update, mock_args, mock_config):
+        """正規表現にマッチしないファイル名の場合 None"""
+        mock_config.set("DEFAULT", "srx345.file", "noversion.tgz")
+        mock_config.set("DEFAULT", "srx345.hash", "dummy")
+        dev = MagicMock()
+        dev.facts = {"model": "SRX345"}
+        result = junos_update.get_planning_version("test-host", dev)
+        assert result is None


### PR DESCRIPTION
## Summary
- pytestベースのテストスイート（45テスト）を新規構築
  - `test_version.py`: バージョン比較、日時パース、計画バージョン抽出（15テスト）
  - `test_config.py`: INI読込、モデルファイル/ハッシュ取得、hashcacheスレッド安全性（14テスト）
  - `test_connect.py`: NETCONF接続の正常/各種例外ハンドリング（6テスト）
  - `test_process_host.py`: process_host()の統合テスト — 接続失敗、例外キャッチ、dev.close()確実実行（10テスト）
- GitHub Actions CI（Python 3.12/3.13マトリクス）で構文チェック + pytest を自動実行
- 仮想JUNOS不要 — 全テストがモックベースで実機接続なしに動作

Closes #21

## Test plan
- [x] `pytest tests/ -v --tb=short` — 45テスト全PASS（ローカル Python 3.14）
- [x] `python3 -m py_compile junos-update` — 構文チェックOK
- [ ] GitHub Actions CI が push/PR で正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)