### PR TITLE
feat: サブコマンド方式に移行し、RSI/SCF並列収集を統合

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Juniperデバイスのモデルを自動検出し、JUNOSパッケージを自�
 - SCP転送＋チェックサム検証による安全なパッケージコピー
 - インストール前のパッケージ検証（validate）
 - ロールバック対応（MX/EX/SRXモデル別処理）
-- スケジュールリブート（`--rebootat`）
+- スケジュールリブート
+- RSI/SCF の並列収集
 - ドライランモード（`--dry-run`）で事前確認
+- ThreadPoolExecutor による並列実行
 - 設定ファイル（INI形式）によるホスト・パッケージ管理
 
 ## 目次
@@ -86,6 +88,8 @@ sshkey = id_ed25519   # SSH秘密鍵ファイル
 port = 830            # NETCONFポート
 hashalgo = md5        # チェックサムアルゴリズム
 rpath = /var/tmp      # リモートパス
+# huge_tree = true    # 大きなXMLレスポンスを許可
+# RSI_DIR = ./rsi/    # RSI/SCFファイルの出力先
 
 # モデル名.file = パッケージファイル名
 # モデル名.hash = チェックサム値
@@ -116,148 +120,122 @@ EX4300-32F.hash = 353a0dbd8ff6a088a593ec246f8de4f4
 ## 使い方
 
 ```
-junos-ops [-h] [-c CONFIG] [--list] [--longlist] [-n] [--dry-run]
-             [--copy] [--install] [--update] [--force] [--showversion]
-             [--rollback] [--rebootat REBOOTAT] [-d] [-V]
-             [hostname ...]
+junos-ops <subcommand> [options] [hostname ...]
 ```
 
-### オプション一覧
+### サブコマンド一覧
+
+| サブコマンド | 説明 |
+|-------------|------|
+| `upgrade` | コピー＋インストールを一括実行 |
+| `copy` | ローカルからリモートへパッケージをコピー |
+| `install` | コピー済みパッケージをインストール |
+| `rollback` | 前バージョンにロールバック |
+| `version` | running/planning/pendingバージョンとリブート予定を表示 |
+| `reboot --at YYMMDDHHMM` | 指定日時にリブートをスケジュール |
+| `ls [-l]` | リモートパスのファイル一覧 |
+| `rsi` | RSI/SCF を並列収集 |
+| （なし） | デバイスファクト（device facts）を表示 |
+
+### 共通オプション
 
 | オプション | 説明 |
 |-----------|------|
 | `hostname` | 対象ホスト名（省略時は設定ファイル内の全ホスト） |
 | `-c`, `--config CONFIG` | 設定ファイル指定（デフォルト: `config.ini` → `~/.config/junos-ops/config.ini`） |
-| `--copy` | ローカルからリモートへパッケージをコピー |
-| `--install` | コピー済みパッケージをインストール |
-| `--update`, `--upgrade` | コピー＋インストールを一括実行 |
-| `--force` | 条件を無視して強制実行 |
-| `--showversion`, `--version` | running/planning/pendingバージョンとリブート予定を表示 |
-| `--rollback` | 前バージョンにロールバック |
-| `--rebootat YYMMDDHHMM` | 指定日時にリブートをスケジュール（例: `2501020304`） |
-| `--list`, `-ls` | リモートパスのファイル一覧（短縮表示） |
-| `--longlist`, `-ll` | リモートパスのファイル一覧（詳細表示） |
 | `-n`, `--dry-run` | テスト実行（接続とメッセージ出力のみ、実行しない） |
 | `-d`, `--debug` | デバッグ出力 |
-| `-V` | プログラムバージョン表示 |
-
-引数なしで実行するとデバイスファクト（device facts）を表示します。
+| `--force` | 条件を無視して強制実行 |
+| `--workers N` | 並列実行数（デフォルト: upgrade系=1, rsi=20） |
+| `--version` | プログラムバージョン表示 |
 
 ## ワークフロー
 
 JUNOSアップデートの典型的な作業フローです。
 
 ```
-1. --dry-run で事前確認
-   junos-ops --update --dry-run hostname
+1. dry-run で事前確認
+   junos-ops upgrade -n hostname
 
-2. --update でコピー＋インストール（--copy + --install）
-   junos-ops --update hostname
+2. upgrade でコピー＋インストール
+   junos-ops upgrade hostname
 
-3. --showversion でバージョン確認
-   junos-ops --showversion hostname
+3. version でバージョン確認
+   junos-ops version hostname
 
-4. --rebootat でリブート日時を指定
-   junos-ops --rebootat 2506130500 hostname
+4. reboot でリブート日時を指定
+   junos-ops reboot --at 2506130500 hostname
 ```
 
-問題が発生した場合は `--rollback` で前バージョンに戻せます。
+問題が発生した場合は `rollback` で前バージョンに戻せます。
 
 ## 実行例
 
-### --update（パッケージ更新）
+### upgrade（パッケージ更新）
 
 ```
-% junos-ops --update rt1.example.jp
-[rt1.example.jp]
+% junos-ops upgrade rt1.example.jp
+# rt1.example.jp
 remote: jinstall-ppc-18.4R3-S10-signed.tgz is not found.
 copy: system storage cleanup successful
 rt1.example.jp: cleaning filesystem ...
-rt1.example.jp: before copy, computing checksum on remote package: /var/tmp/jinstall-ppc-18.4R3-S10-signed.tgz
-rt1.example.jp: b'jinstall-ppc-18.4R3-S10-signed.tgz': 38010880 / 380102074 (10%)
-...
 rt1.example.jp: b'jinstall-ppc-18.4R3-S10-signed.tgz': 380102074 / 380102074 (100%)
-rt1.example.jp: after copy, computing checksum on remote package: /var/tmp/jinstall-ppc-18.4R3-S10-signed.tgz
 rt1.example.jp: checksum check passed.
 install: clear reboot schedule successful
-install: rescue config save suecessful
-rt1.example.jp: validating software against current config, please be patient ...
+install: rescue config save successful
 rt1.example.jp: software validate package-result: 0
 ```
 
-### --showversion（バージョン確認）
+### version（バージョン確認）
 
 ```
-% junos-ops --showversion
-[rt1.example.jp]
-hostname: rt1
-model: MX5-T
-running version: 18.4R3-S7.2
-planning version: 18.4R3-S10
- 	running version seems older than planning version.
-	pending version: 18.4R3-S10
-running version seems older than pending version. Please plan to reboot.
-local package: jinstall-ppc-18.4R3-S10-signed.tgz is found. checksum is OK.
-remote package: jinstall-ppc-18.4R3-S10-signed.tgz is found. checksum is OK.
-reboot requested by exadmin at Sat Dec  4 05:00:00 2021
-
-[rt2.example.jp]
-hostname: rt2
-model: EX3400-24T
-running version: 18.4R3-S9.2
-planning version: 18.4R3-S10
-	running version seems older than planning version.
-pending version: 18.4R3-S10
-	running version seems older than pending version. Please plan to reboot.
-local package: junos-arm-32-18.4R3-S10.tgz is found. checksum is OK.
-remote package: junos-arm-32-18.4R3-S10.tgz is not found.
-reboot requested by exadmin at Wed Dec  8 01:00:00 2021
+% junos-ops version rt1.example.jp
+# rt1.example.jp
+  - hostname: rt1
+  - model: MX5-T
+  - running version: 18.4R3-S7.2
+  - planning version: 18.4R3-S10
+    - running='18.4R3-S7.2' < planning='18.4R3-S10'
+  - pending version: 18.4R3-S10
+    - running='18.4R3-S7.2' < pending='18.4R3-S10' : Please plan to reboot.
+  - reboot requested by exadmin at Sat Dec  4 05:00:00 2021
 ```
 
-### --dry-run（テスト実行）
+### rsi（RSI/SCF並列収集）
 
 ```
-% junos-ops --update --dry-run srx.example.jp
-[srx.example.jp]
-remote package: junos-srxentedge-x86-64-18.4R3-S9.2.tgz is not found.
-dry-run: request system storage cleanup
-dry-run: scp(cheksum:md5) junos-srxentedge-x86-64-18.4R3-S9.2.tgz srx.example.jp:/var/tmp
-dry-run: clear system reboot
-dry-run: request system configuration rescue save
-dry-run: request system software add /var/tmp/junos-srxentedge-x86-64-18.4R3-S9.2.tgz
+% junos-ops rsi --workers 5 rt1.example.jp rt2.example.jp
+# rt1.example.jp
+  rt1.example.jp.SCF done
+  rt1.example.jp.RSI done
+# rt2.example.jp
+  rt2.example.jp.SCF done
+  rt2.example.jp.RSI done
 ```
 
-### --rebootat（スケジュールリブート）
+### reboot（スケジュールリブート）
 
 ```
-% junos-ops --rebootat 2506130500 --force
-[INFO]main - host='rt1.example.jp'
-[INFO]reboot - Shutdown at Fri Jun 13 05:00:00 2025. [pid 97978]
-
-[INFO]main - host='rt2.example.jp'
-[INFO]reboot - ANY SHUTDWON/REBOOT SCHEDULE EXISTS
-[INFO]reboot - force clear reboot
-[INFO]clear_reboot - clear reboot schedule successful
-[INFO]reboot - Shutdown at Fri Jun 13 05:00:00 2025. [pid 3321]
+% junos-ops reboot --at 2506130500 rt1.example.jp
+# rt1.example.jp
+	Shutdown at Fri Jun 13 05:00:00 2025. [pid 97978]
 ```
 
 ### 引数なし（デバイスファクト表示）
 
 ```
 % junos-ops gw1.example.jp
-[gw1.example.jp]
+# gw1.example.jp
 {'2RE': True,
  'hostname': 'gw1',
  'model': 'MX240',
  'version': '18.4R3-S7.2',
- 'version_RE0': '18.4R3-S7.2',
- 'version_RE1': '18.4R3-S7.2',
  ...}
 ```
 
 ## 対応モデル
 
-レシピファイルでモデル名とパッケージファイルを定義することで、任意のJuniperモデルに対応できます。設定例に含まれるモデル:
+設定ファイルでモデル名とパッケージファイルを定義することで、任意のJuniperモデルに対応できます。設定例に含まれるモデル:
 
 | シリーズ | モデル例 |
 |---------|---------|

--- a/config.ini
+++ b/config.ini
@@ -8,6 +8,8 @@ sshkey = id_ed25519
 port = 830
 hashalgo = md5
 rpath = /var/tmp
+# huge_tree = true     # 大きなXMLレスポンスを許可（huge_tree対応機器向け）
+# RSI_DIR = ./rsi/     # RSI/SCFファイルの出力先ディレクトリ
 
 EX2300-24T.file = junos-arm-32-18.4R3-S10.tgz
 EX2300-24T.hash = e233b31a0b9233bc4c56e89954839a8a

--- a/junos_ops/__init__.py
+++ b/junos_ops/__init__.py
@@ -1,3 +1,3 @@
 """junos-ops: Juniper Networks デバイス運用ツール"""
 
-__version__ = "0.3"
+__version__ = "0.4"

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -1,0 +1,157 @@
+"""共通機能: 設定読込、接続管理、ターゲット決定、並列実行"""
+
+from concurrent import futures
+from jnpr.junos import Device
+from jnpr.junos.exception import (
+    ConnectAuthError,
+    ConnectClosedError,
+    ConnectError,
+    ConnectRefusedError,
+    ConnectTimeoutError,
+    ConnectUnknownHostError,
+)
+import configparser
+import os
+import sys
+import threading
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+config = None
+config_lock = threading.Lock()
+args = None
+
+DEFAULT_CONFIG = "config.ini"
+
+
+def get_default_config():
+    """設定ファイルのデフォルトパスを探索順に返す"""
+    # カレントディレクトリ
+    if os.path.isfile(DEFAULT_CONFIG):
+        return DEFAULT_CONFIG
+    # XDG_CONFIG_HOME（未設定なら ~/.config）
+    xdg = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+    xdg_path = os.path.join(xdg, "junos-ops", DEFAULT_CONFIG)
+    if os.path.isfile(xdg_path):
+        return xdg_path
+    return DEFAULT_CONFIG
+
+
+def read_config():
+    global config
+    config = configparser.ConfigParser(allow_no_value=True)
+    config.read(args.config)
+    if len(config.sections()) == 0:
+        print(args.config, "is empty")
+        return True
+    for section in config.sections():
+        if config.has_option(section, "host"):
+            host = config.get(section, "host")
+        else:
+            host = None
+        if host is None:
+            # host is [section] name
+            config.set(section, "host", section)
+        if args.debug:
+            for key in config[section]:
+                print(section, ">", key, ":", config[section][key])
+            print()
+    return False
+
+
+def connect(hostname):
+    if args.debug:
+        print("connect: start")
+    dev = Device(
+        host=config.get(hostname, "host"),
+        port=int(config.get(hostname, "port")),
+        user=config.get(hostname, "id"),
+        passwd=config.get(hostname, "pw"),
+        ssh_private_key_file=config.get(hostname, "sshkey"),
+        huge_tree=config.getboolean(hostname, "huge_tree", fallback=False),
+    )
+    err = None
+    try:
+        dev.open()
+        err = False
+    except ConnectAuthError as e:
+        print("Authentication credentials fail to login: {0}".format(e))
+        dev = None
+        err = True
+    except ConnectRefusedError as e:
+        print("NETCONF Connection refused: {0}".format(e))
+        dev = None
+        err = True
+    except ConnectTimeoutError as e:
+        print("Connection timeout: {0}".format(e))
+        dev = None
+        err = True
+    except ConnectError as e:
+        print("Cannot connect to device: {0}".format(e))
+        dev = None
+        err = True
+    except ConnectUnknownHostError as e:
+        print("Unknown Host: {0}".format(e))
+        dev = None
+        err = True
+    except Exception as e:
+        print(e)
+        dev = None
+        err = True
+    if args.debug:
+        print("connect: err=", err, "dev=", dev)
+    if args.debug:
+        print("connect: end")
+    return err, dev
+
+
+def get_targets():
+    """specialhosts が指定されていればそのリスト、なければ全セクション"""
+    targets = []
+    if len(args.specialhosts) == 0:
+        for i in config.sections():
+            tmp = config.get(i, "host")
+            logger.debug(f"{i=} {tmp=}")
+            if tmp is not None:
+                targets.append(i)
+            else:
+                print(i, "is not found in", args.config)
+                sys.exit(1)
+    else:
+        for i in args.specialhosts:
+            if config.has_section(i):
+                tmp = config.get(i, "host")
+            else:
+                print(i, "is not found in", args.config)
+                sys.exit(1)
+            logger.debug(f"{i=} {tmp=}")
+            targets.append(i)
+    return targets
+
+
+def run_parallel(func, targets, max_workers=1):
+    """ターゲットリストに対して関数を並列実行する
+
+    max_workers=1 の場合はシリアル実行（既存動作と同じ）
+    """
+    if max_workers <= 1:
+        results = {}
+        for target in targets:
+            results[target] = func(target)
+        return results
+
+    with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_target = {
+            executor.submit(func, target): target
+            for target in targets
+        }
+        results = {}
+        for future in futures.as_completed(future_to_target):
+            target = future_to_target[future]
+            try:
+                results[target] = future.result()
+            except Exception as e:
+                logger.error(f"{target} generated an exception: {e}")
+                results[target] = 1
+        return results

--- a/junos_ops/rsi.py
+++ b/junos_ops/rsi.py
@@ -1,0 +1,89 @@
+"""RSI/SCF 収集機能: show configuration と request support information の並列収集"""
+
+from lxml import etree
+from logging import getLogger
+
+from junos_ops import common
+
+logger = getLogger(__name__)
+
+
+def get_support_information(dev):
+    """機種別タイムアウト設定で request support information を実行する
+
+    :returns: RPC レスポンス、失敗時は None
+    """
+    try:
+        if dev.facts["personality"] == "SRX_BRANCH":
+            # SRX3xx series is SLOW
+            timeout = 1200
+        elif dev.facts["model"] == "EX2300-24T":
+            timeout = 1200
+        elif len(dev.facts["model_info"]) >= 2:
+            # Virtual Chassis is more SLOW
+            timeout = 1800
+            if dev.facts["model"] == "QFX5110-48S-4C":
+                # QFX5110-48S-4C is most SLOW
+                timeout = 2400
+        else:
+            timeout = 600
+
+        logger.debug(f"get_support_information: {dev.facts['hostname']} timeout={timeout}")
+
+        if dev.facts.get("srx_cluster") == "True":
+            rpc = dev.rpc.get_support_information(
+                {"format": "text"}, dev_timeout=timeout, node="primary"
+            )
+        else:
+            rpc = dev.rpc.get_support_information(
+                {"format": "text"}, dev_timeout=timeout
+            )
+        return rpc
+    except Exception as e:
+        logger.error(f"get_support_information: {e}")
+        return None
+
+
+def cmd_rsi(hostname) -> int:
+    """1ホストの SCF + RSI 収集→ファイル出力
+
+    :returns: 0=成功, 非0=エラー
+    """
+    logger.debug(f"cmd_rsi: {hostname} start")
+    print(f"# {hostname}")
+
+    err, dev = common.connect(hostname)
+    if err or dev is None:
+        return 1
+
+    rsi_dir = common.config.get(hostname, "RSI_DIR", fallback="./")
+
+    try:
+        # show configuration | display set → SCF ファイル
+        output_str = dev.cli("show configuration | display set")
+        scf_path = f"{rsi_dir}{hostname}.SCF"
+        with open(scf_path, mode="w") as f:
+            f.write(output_str.strip())
+        print(f"  {hostname}.SCF done")
+
+        # request support information → RSI ファイル
+        rpc = get_support_information(dev)
+        if rpc is None:
+            logger.error(f"{hostname}: get_support_information failed")
+            return 2
+
+        output_str = etree.tostring(rpc, encoding="unicode", method="text")
+        rsi_path = f"{rsi_dir}{hostname}.RSI"
+        with open(rsi_path, mode="w") as f:
+            f.write(output_str.strip())
+        print(f"  {hostname}.RSI done")
+
+        return 0
+    except Exception as e:
+        logger.error(f"{hostname}: {e}")
+        return 1
+    finally:
+        try:
+            dev.close()
+        except Exception:
+            pass

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1,0 +1,782 @@
+"""upgrade 系機能: パッケージ転送・インストール・ロールバック・リブート・バージョン管理"""
+
+from looseversion import LooseVersion
+from jnpr.junos.exception import (
+    ConnectError,
+    RpcError,
+    RpcTimeoutError,
+)
+from jnpr.junos.utils.config import Config
+from jnpr.junos.utils.fs import FS
+from jnpr.junos.utils.sw import SW
+from lxml import etree
+from ncclient.operations.errors import TimeoutExpiredError
+import argparse
+import datetime
+import re
+from logging import getLogger
+
+from junos_ops import common
+
+logger = getLogger(__name__)
+
+
+def copy(hostname, dev):
+    if common.args.debug:
+        print("copy: start")
+    if common.args.force:
+        if common.args.debug:
+            print("copy: force copy")
+    else:
+        if check_running_package(hostname, dev):
+            print("Already Running, COPY Skip.")
+            return False
+        if check_remote_package(hostname, dev):
+            print("remote package is already copied successfully")
+            return False
+
+    # request-system-storage-cleanup
+    if common.args.dry_run:
+        print("dry-run: request system storage cleanup")
+    else:
+        try:
+            rpc = dev.rpc.request_system_storage_cleanup(
+                no_confirm=True, dev_timeout=60
+            )
+            # default dev_timeout is 30 seconds, but it's not enough QFX series.
+            xml_str = etree.tostring(rpc, encoding="unicode")
+            if common.args.debug:
+                print("copy: request-system-storage-cleanup=", xml_str)
+            if xml_str.find("<success/>") >= 0:
+                print("copy: system storage cleanup successful")
+            else:
+                print("copy: system storage cleanup failed")
+                return True
+        except RpcError as e:
+            print("system storage cleanup failure caused by RpcError:", e)
+            return True
+        except RpcTimeoutError as e:
+            print("system storage cleanup failure caused by RpcTimeoutError:", e)
+            return True
+        except Exception as e:
+            print(e)
+            return True
+
+    # copy
+    if common.args.dry_run:
+        print(
+            "dry-run: scp(checksum:%s) %s %s:%s"
+            % (
+                common.config.get(hostname, "hashalgo"),
+                get_model_file(hostname, dev.facts["model"]),
+                hostname,
+                common.config.get(hostname, "rpath"),
+            )
+        )
+        ret = False
+    else:
+        try:
+            sw = SW(dev)
+            result = sw.safe_copy(
+                get_model_file(hostname, dev.facts["model"]),
+                remote_path=common.config.get(hostname, "rpath"),
+                progress=True,
+                cleanfs=True,
+                cleanfs_timeout=300,  # default 300
+                checksum=get_model_hash(hostname, dev.facts["model"]),
+                checksum_timeout=1200,  # default 300
+                checksum_algorithm=common.config.get(hostname, "hashalgo"),
+                force_copy=common.args.force,
+            )
+            if result:
+                if common.args.debug:
+                    print("copy: successful")
+                ret = False
+            else:
+                if common.args.debug:
+                    print("copy: failed")
+                ret = True
+        except TimeoutExpiredError as e:
+            print("Copy failure caused by TimeoutExpiredError:", e)
+            ret = True
+        except RpcTimeoutError as e:
+            print("Copy failure caused by RpcTimeoutError:", e)
+            return True
+        except Exception as e:
+            print(e)
+            ret = True
+
+    if common.args.debug:
+        print("copy: end", ret)
+    return ret
+
+
+def rollback(hostname, dev):
+    if common.args.dry_run:
+        print("dry-run: request system software rollback")
+    else:
+        try:
+            rpc = dev.rpc.request_package_rollback({"format": "text"}, dev_timeout=120)
+            # default dev_timeout is 30 seconds, but it's not enough SRX4600, MX5 and QFX5110.
+            xml_str = etree.tostring(rpc, encoding="unicode")
+            if common.args.debug:
+                print("rollback: rpc=", rpc, "xml_str=", xml_str)
+            if (
+                xml_str.find("Deleting bootstrap installer") >= 0  # MX
+                or xml_str.find("NOTICE: The 'pending' set has been removed") >= 0  # EX
+                or xml_str.find("will become active at next reboot") >= 0  # SRX3xx
+                or xml_str.find("Rollback of staged upgrade succeeded") >= 0  # SRX1500
+                or xml_str.find("There is NO image for ROLLBACK") >= 0  # SRX4600
+            ):
+                print(f"rollback: request system software rollback successful:\n{xml_str}")
+            else:
+                print(f"rollback: request system software rollback failed:\n{xml_str}")
+                return True
+        except RpcError as e:
+            print("request system software rollback failure caused by RpcError:", e)
+            return True
+        except RpcTimeoutError as e:
+            print(
+                "request system software rollback failure caused by RpcTimeoutError:",
+                e,
+            )
+            return True
+        except Exception as e:
+            print(e)
+            return True
+    return False
+
+
+def clear_reboot(dev) -> bool:
+    # clear system reboot
+    if common.args.dry_run:
+        print("\tdry-run: clear system reboot")
+    else:
+        try:
+            rpc = dev.rpc.clear_reboot({"format": "text"})
+            xml_str = etree.tostring(rpc, encoding="unicode")
+            logger.debug(f"{rpc=} {xml_str=}")
+            if (
+                xml_str.find("No shutdown/reboot scheduled.") >= 0
+                or xml_str.find("Terminating...") >= 0
+            ):
+                logger.debug("clear reboot schedule successful")
+                print("\tclear reboot schedule successful")
+            else:
+                logger.debug("clear reboot schedule failed")
+                print("\tclear reboot schedule failed")
+                return True
+        except RpcError as e:
+            logger.error(f"Clear reboot failure caused by RpcError: {e}")
+            return True
+        except RpcTimeoutError as e:
+            logger.error(f"Clear reboot failure caused by RpcTimeoutError: {e}")
+            return True
+        except Exception as e:
+            logger.error(e)
+            return True
+    return False
+
+
+def install(hostname, dev):
+    if common.args.debug:
+        print("install: start")
+    if common.args.force:
+        if common.args.debug:
+            print("install: force install")
+    else:
+        if check_running_package(hostname, dev):
+            print("Already Running, INSTALL Skip.")
+            return False
+
+    pending = get_pending_version(hostname, dev)
+    logger.debug(f"{pending=}")
+    if pending is not None:
+        planning = get_planning_version(hostname, dev)
+        logger.debug(f"{planning=}")
+        ret = compare_version(pending, planning)
+        logger.debug(f"install: compare_version={ret}")
+        if ret == 1:
+            logger.debug(f"{pending=} > {planning=} : No need install.")
+            print(f"\t{pending=} > {planning=} : No need install.")
+        elif ret == -1:
+            logger.debug(f"{pending=} < {planning=} : NEED INSTALL.")
+            print(f"\t{pending=} < {planning=} : NEED INSTALL.")
+        elif ret == 0:
+            logger.debug(f"{pending=} = {planning=} : No need install.")
+            print(f"\t{pending=} = {planning=} : No need install.")
+
+        if ret == 1 or ret == 0:
+            if common.args.force:
+                # force INSTALL
+                pass
+            else:
+                return False
+
+        ret = rollback(hostname, dev)
+        if ret:
+            if common.args.force:
+                pass
+            else:
+                return True
+
+    # EX series delete remote package after installed. so, must check first pending version before copy.
+    if common.args.dry_run and (common.args.copy or common.args.update):
+        print("dry-run: skip remote package check")
+    elif check_remote_package(hostname, dev) is not True and common.args.install:
+        # install() does not copy
+        logger.info("remote package file not found. Please consider --copy before --install")
+        return True
+
+    if copy(hostname, dev):
+        return True
+
+    if clear_reboot(dev):
+        return True
+
+    # request system configuration rescue save
+    if common.args.dry_run:
+        print("dry-run: request system configuration rescue save")
+    else:
+        cu = Config(dev)
+        try:
+            ret = cu.rescue("save")
+            if ret:
+                print("install: rescue config save successful")
+            else:
+                print("install: rescue config save failed")
+                return True
+        except ValueError as e:
+            print("wrong rescue action", e)
+            return True
+        except Exception as e:
+            print(e)
+            return True
+
+    # request system software add ...
+    if common.args.dry_run:
+        print(
+            "dry-run: request system software add %s/%s"
+            % (
+                common.config.get(hostname, "rpath"),
+                get_model_file(hostname, dev.facts["model"]),
+            )
+        )
+        ret = False
+    else:
+        sw = SW(dev)
+        status, msg = sw.install(
+            get_model_file(hostname, dev.facts["model"]),
+            remote_path=common.config.get(hostname, "rpath"),
+            progress=True,
+            validate=True,
+            cleanfs=True,
+            no_copy=True,
+            issu=False,
+            nssu=False,
+            timeout=2400,  # default 1800
+            cleanfs_timeout=300,  # default 300
+            checksum=get_model_hash(hostname, dev.facts["model"]),
+            checksum_timeout=1200,  # default 300
+            checksum_algorithm=common.config.get(hostname, "hashalgo"),
+            force_copy=common.args.force,
+            all_re=True,
+        )
+        del sw
+        logger.debug(f"{msg=}")
+        if status:
+            logger.info("install successful")
+            ret = False
+        else:
+            logger.info("install failed")
+            ret = True
+
+    logger.debug(f"end {ret=}")
+    return ret
+
+
+def get_model_file(hostname, model):
+    try:
+        return common.config.get(hostname, model.lower() + ".file")
+    except Exception as e:
+        logger.error(f"{hostname}: {model.lower()}.file not found in recipe: {e}")
+        raise
+
+
+def get_model_hash(hostname, model):
+    try:
+        return common.config.get(hostname, model.lower() + ".hash")
+    except Exception as e:
+        logger.error(f"{hostname}: {model.lower()}.hash not found in recipe: {e}")
+        raise
+
+
+def get_hashcache(hostname, file):
+    with common.config_lock:
+        if common.config.has_section(hostname) is False:
+            return None
+        if common.config.has_option(hostname, file + "hashcache"):
+            hashcache = common.config.get(hostname, file + "hashcache")
+        else:
+            hashcache = None
+        return hashcache
+
+
+def set_hashcache(hostname, file, value):
+    with common.config_lock:
+        if common.config.has_section(hostname) is False:
+            # "localhost"
+            common.config.add_section(hostname)
+        common.config.set(hostname, file + "hashcache", value)
+
+
+def check_local_package(hostname, dev):
+    """check local package
+    :returns:
+       * ``True`` file found, checksum correct.
+       * ``False`` file found, checksum incorrect.
+       * ``None`` file not found.
+    """
+    # local package check
+    # model, file, hash, algo
+    model = dev.facts["model"]
+    file = get_model_file(hostname, model)
+    pkg_hash = get_model_hash(hostname, model)
+    if len(file) == 0 or len(pkg_hash) == 0:
+        return None
+    algo = common.config.get(hostname, "hashalgo")
+    sw = SW(dev)
+    if get_hashcache("localhost", file) == pkg_hash:
+        print(f"  - local package: {file} is found. checksum(cache) is OK.")
+        return True
+    ret = None
+    try:
+        val = sw.local_checksum(file, algorithm=algo)
+        if val == pkg_hash:
+            print(f"  - local package: {file} is found. checksum is OK.")
+            set_hashcache("localhost", file, val)
+            ret = True
+        else:
+            print(f"  - local package: {file} is found. checksum is BAD. COPY AGAIN!")
+            ret = False
+    except FileNotFoundError as e:
+        print(f"  - local package: {file} is not found.")
+        logger.debug(e)
+    except Exception as e:
+        logger.error(e)
+    del sw
+    return ret
+
+
+def check_remote_package(hostname, dev):
+    """check remote package
+    :returns:
+       * ``True`` file found, checksum correct.
+       * ``False`` file found, checksum incorrect.
+       * ``None`` file not found.
+    """
+    # remote package check
+    # model, file, hash, algo
+    model = dev.facts["model"]
+    file = get_model_file(hostname, model)
+    pkg_hash = get_model_hash(hostname, model)
+    if len(file) == 0 or len(pkg_hash) == 0:
+        return None
+    algo = common.config.get(hostname, "hashalgo")
+    sw = SW(dev)
+    ret = None
+    if get_hashcache(hostname, file) == pkg_hash:
+        print(f"  - remote package: {file} is found. checksum(cache) is OK.")
+        return True
+    try:
+        val = sw.remote_checksum(
+            common.config.get(hostname, "rpath") + "/" + file, algorithm=algo
+        )
+        if val is None:
+            print(f"  - remote package: {file} is not found.")
+        elif val == pkg_hash:
+            print(f"  - remote package: {file} is found. checksum is OK.")
+            set_hashcache(hostname, file, val)
+            ret = True
+        else:
+            print(f"  - remote package: {file} is found. checksum is BAD. COPY AGAIN!")
+            ret = False
+    except RpcError as e:
+        logger.error("Unable to remote checksum: {0}".format(e))
+    except Exception as e:
+        logger.error(e)
+    del sw
+    return ret
+
+
+def list_remote_path(hostname, dev):
+    # list remote path
+    if common.args.debug:
+        print("list_remote_path: start")
+    # file list /var/tmp/
+    fs = FS(dev)
+    rpath = common.config.get(hostname, "rpath")
+    dir_info = fs.ls(path=rpath, brief=False)
+    print(dir_info.get("path") + ":")
+    a = dir_info.get("files")
+    if common.args.list_format == "short":
+        for i in a.keys():
+            b = a.get(i)
+            if b.get("type") == "file":
+                print(b.get("path"))
+            else:
+                print(b.get("path") + "/")
+    else:
+        for i in a.keys():
+            b = a.get(i)
+            print(
+                "%s %s %9d %s %s"
+                % (
+                    b.get("permissions_text"),
+                    b.get("owner"),
+                    b.get("size"),
+                    b.get("ts_date"),
+                    b.get("path"),
+                )
+            )
+        print("total files: %d" % dir_info.get("file_count"))
+    if common.args.debug:
+        print("list_remote_path: end")
+    return dir_info
+
+
+def dry_run(hostname, dev):
+    if common.args.debug:
+        print("dry-run: start")
+        print("hostname: ", dev.facts["hostname"])
+        print("model: ", dev.facts["model"])
+        print("file:", get_model_file(hostname, dev.facts["model"]))
+        print("hash:", get_model_hash(hostname, dev.facts["model"]))
+        print("algo:", common.config.get(hostname, "hashalgo"))
+    # show hostname, model, file, hash and algo
+    # local package check
+    local = check_local_package(hostname, dev)
+    # remote package check
+    remote = check_remote_package(hostname, dev)
+    if common.args.debug:
+        print("dry-run: end")
+    if local and remote:
+        return True
+    else:
+        return False
+
+
+def check_running_package(hostname, dev):
+    """compare running version with planning version
+    :returns:
+       * ``True`` same(correct)
+       * ``False`` diffrent(incorrect)
+    """
+    if common.args.debug:
+        print("check_running_package: start")
+    ret = None
+    ver = dev.facts["version"]
+    rever = re.sub(r"\.", r"\\.", ver)
+    if common.args.debug:
+        print("check_running_package: ver", ver)
+        print("check_running_package: rever", rever)
+    m = re.search(rever, get_model_file(hostname, dev.facts["model"]))
+    if common.args.debug:
+        print("check_running_package: m", m)
+    if m is None:
+        # unmatch(different version)
+        ret = False
+    else:
+        # match(same version)
+        ret = True
+    if common.args.debug:
+        print("check_running_package: end")
+    return ret
+
+
+def compare_version(left: str, right: str) -> int | None:
+    """compare version left and right
+
+    :param left: version left string, ex 18.4R3-S9.2
+    :param right: version right string, ex 18.4R3-S10
+
+    :return:  1 if left  > right
+              0 if left == right
+             -1 if left  < right
+    """
+    if common.args.debug:
+        print(f"compare_version: left={left}, right={right}.")
+    if left is None or right is None:
+        return None
+    if LooseVersion(left.replace("-S", "00")) > LooseVersion(right.replace("-S", "00")):
+        return 1
+    if LooseVersion(left.replace("-S", "00")) < LooseVersion(right.replace("-S", "00")):
+        return -1
+    return 0
+
+
+def get_pending_version(hostname, dev) -> str:
+    """
+    :returns:
+       * ``None`` not exist
+       * ``str`` pending version string
+    """
+    pending = None
+    try:
+        rpc = dev.rpc.get_software_information({"format": "text"})
+        xml_str = etree.tostring(rpc, encoding="unicode")
+        if common.args.debug:
+            print(
+                "get_pending_version: rpc=", rpc, "type(xml_str)=", type(xml_str), "xml_str=", xml_str
+            )
+        if dev.facts["personality"] == "SWITCH":
+            if common.args.debug:
+                print("get_pending_version: EX/QFX series")
+            # Pending: 18.4R3-S10
+            m = re.search(r"^Pending:\s(.*)$", xml_str, re.MULTILINE)
+            if m is not None:
+                pending = m.group(1)
+        elif dev.facts["personality"] == "MX":
+            if common.args.debug:
+                print("get_pending_version: MX series")
+            # JUNOS Installation Software [18.4R3-S10]
+            m = re.search(
+                r"^JUNOS\sInstallation\sSoftware\s\[(.*)\]$", xml_str, re.MULTILINE
+            )
+            if m is not None:
+                pending = m.group(1)
+        elif dev.facts["personality"] == "SRX_BRANCH":
+            # Dual Partition - SRX300, SRX345
+            if common.args.debug:
+                print("get_pending_version: SRX_BRANCH series")
+            xml = dev.rpc.get_snapshot_information(media="internal")
+            if common.args.debug:
+                print(f"get_snapshot_information: xml={etree.dump(xml)}")
+            primary = False
+            for i in range(len(xml)):
+                if common.args.debug:
+                    print(
+                        f"get_snapshot_information: i={i}, tag={xml[i].tag}, text={xml[i].text}"
+                    )
+                if (
+                    xml[i].tag == "snapshot-medium"
+                    and re.match(".*primary", xml[i].text, re.MULTILINE | re.DOTALL)
+                    is not None
+                ):
+                    if common.args.debug:
+                        print("primary find")
+                    primary = True
+                if (
+                    primary
+                    and xml[i].tag == "software-version"
+                    and xml[i][0].tag == "package"
+                    and xml[i][0][1].tag == "package-version"
+                ):
+                    pending = xml[i][0][1].text.strip()
+                    break
+        elif (
+            dev.facts["personality"] == "SRX_MIDRANGE"
+            or dev.facts["personality"] == "SRX_HIGHEND"
+        ):
+            # SRX1500, SRX4600
+            if common.args.debug:
+                print("get_pending_version: SRX_MIDRANGE or SRX_HIGHEND series")
+            # show log install
+            # upgrade_platform: Staging of /var/tmp/junos-srxentedge-x86-64-20.4R3.8-linux.tgz completed
+            # &lt;package-result&gt;0&lt;/package-result&gt;
+            try:
+                rpc = dev.rpc.get_log({"format": "text"}, filename="install")
+                xml_str = etree.tostring(rpc, encoding="unicode")
+                if common.args.debug:
+                    print(
+                        "get_pending_version: rpc=",
+                        rpc,
+                        "type(xml_str)=",
+                        type(xml_str),
+                        "xml_str=",
+                        xml_str,
+                    )
+                if xml_str is not None:
+                    # search from last <output> block
+                    start = xml_str.rfind("&lt;output&gt;")
+                    m = re.search(
+                        r"upgrade_platform: Staging of /var/tmp/.*-(\d{2}\.\d.*\d).*\.tgz completed",
+                        xml_str[start:],
+                        re.MULTILINE,
+                    )
+                    if m is not None:
+                        pending = m.group(1).strip()
+                    m = re.search(
+                        r"&lt;package-result&gt;(\d)&lt;/package-result&gt;",
+                        xml_str[start:],
+                        re.MULTILINE,
+                    )
+                    if m is not None:
+                        if int(m.group(1)) == 0:
+                            pass
+                        else:
+                            pending = None
+            except Exception as e:
+                print(e)
+                return None
+        else:
+            print("Unknown personality:", dev.facts)
+            return None
+    except RpcError as e:
+        print("Show version failure caused by RpcError:", e)
+        return None
+    except RpcTimeoutError as e:
+        print("Show version failure caused by RpcTimeoutError:", e)
+        return None
+    except Exception as e:
+        print(e)
+        return None
+    return pending
+
+
+def get_planning_version(hostname, dev) -> str:
+    planning = None
+    f = get_model_file(hostname, dev.facts["model"])
+    m = re.search(r".*-(\d{2}\.\d.*\d).*\.tgz", f)
+    if m is not None:
+        planning = m.group(1).strip()
+    else:
+        logger.debug("get_planning_version: planning version is not found")
+    return planning
+
+
+def get_reboot_information(hostname, dev):
+    """show system reboot
+    :return: halt requested by exadmin at Sun Dec 19 08:30:00 2021
+             shutdown requested by exadmin at Sun Dec 12 08:30:00 2021
+             reboot requested by exadmin at Sun Dec  5 01:00:00 2021
+             No shutdown/reboot scheduled.
+    """
+    try:
+        rpc = dev.rpc.get_reboot_information({"format": "text"})
+    except RpcError as e:
+        logger.error("Show version failure caused by RpcError:", e)
+        return None
+    except RpcTimeoutError as e:
+        logger.error("Show version failure caused by RpcTimeoutError:", e)
+        return None
+    except Exception as e:
+        logger.error(e)
+        return None
+    xml_str = etree.tostring(rpc, encoding="unicode")
+    if common.args.debug:
+        print(xml_str)
+    m = re.search(
+        r"((halt|shutdown|reboot)\srequested\sby\s.*\sat\s(.*\d)|No\sshutdown\/reboot\sscheduled\.)",
+        xml_str,
+        re.MULTILINE,
+    )
+    if m is None:
+        return None
+    return m.group(1)
+
+
+def show_version(hostname, dev):
+    """show version
+    show running version
+    show pending version
+    check for updated
+    suggest action to copy, install, reboot or beer.
+    """
+
+    logger.debug("start")
+
+    print("  - hostname:", dev.facts["hostname"])
+    print("  - model:", dev.facts["model"])
+    running = dev.facts["version"]
+    print("  - running version:", running)
+
+    # compare with planning version
+    planning = get_planning_version(hostname, dev)
+    print("  - planning version:", planning)
+    ret = compare_version(running, planning)
+    if ret == 1:
+        print(f"    - {running=} > {planning=}")
+    elif ret == -1:
+        print(f"    - {running=} < {planning=}")
+    elif ret == 0:
+        print(f"    - {running=} = {planning=}")
+    # compare with pending version
+    pending = get_pending_version(hostname, dev)
+    print("  - pending version:", pending)
+    ret = compare_version(running, pending)
+    if ret == 1:
+        print(f"    - {running=} > {pending=} : Do you want to rollback?")
+    elif ret == -1:
+        print(f"    - {running=} < {pending=} : Please plan to reboot.")
+    elif ret == 0:
+        print(f"    - {running=} = {pending=}")
+
+    # local package check
+    local = check_local_package(hostname, dev)
+
+    # remote package check
+    remote = check_remote_package(hostname, dev)
+
+    rebooting = get_reboot_information(hostname, dev)
+    if rebooting is not None:
+        print(f"  - {rebooting}")
+
+    logger.debug("end")
+
+    return False
+
+
+def reboot(hostname: str, dev, reboot_dt: datetime.datetime):
+    logger.debug(f"{reboot_dt=}")
+    try:
+        rpc = dev.rpc.get_reboot_information({"format": "text"})
+    except ConnectError as err:
+        logger.error(f"{err=}")
+        return 2
+    xml_str = etree.tostring(rpc, encoding="unicode")
+    logger.debug(f"{xml_str=}")
+    if xml_str.find("No shutdown/reboot scheduled.") >= 0:
+        pass
+    else:
+        logger.debug("ANY SHUTDWON/REBOOT SCHEDULE EXISTS")
+        match = re.search(r"^(\w+) requested by (\w+) at (.*)$", xml_str, re.MULTILINE)
+        if len(match.groups()) == 3:
+            dt = datetime.datetime.strptime(match.group(3), "%a %b %d %H:%M:%S %Y")
+            print(f"\t{match.group(1).upper()} SCHEDULE EXISTS AT {dt}")
+            if common.args.force:
+                logger.debug("force clear reboot")
+                print("\tforce: clear reboot")
+                if clear_reboot(dev):
+                    return 3
+            else:
+                logger.debug("skip clear reboot")
+    # reboot
+    at_str = reboot_dt.strftime("%y%m%d%H%M")
+    sw = SW(dev)
+    try:
+        if common.args.dry_run:
+            msg = f"dry-run: reboot at {at_str}"
+        else:
+            msg = sw.reboot(at=at_str)
+    except ConnectError as e:
+        logger.error(f"{e=}")
+        return 4
+    except RpcError as e:
+        logger.error(f"{e}")
+        return 5
+    print(f"\t{msg}")
+    del sw
+
+    dev.close()
+    logger.debug("success")
+    return 0
+
+
+def yymmddhhmm_type(dt_str: str) -> datetime.datetime:
+    try:
+        return datetime.datetime.strptime(dt_str, "%y%m%d%H%M")
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            f"{e}: {dt_str} must be yymmddhhmm format. ex. 2501020304"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,36 +2,51 @@ import argparse
 import configparser
 import pytest
 
+from junos_ops import common
 from junos_ops import cli as junos_update_mod
+from junos_ops import upgrade as junos_upgrade_mod
+
+
+@pytest.fixture
+def junos_common():
+    """common モジュールを返す"""
+    return common
 
 
 @pytest.fixture
 def junos_update():
-    """junos_ops.cli モジュールを返す"""
+    """junos_ops.cli モジュールを返す（後方互換）"""
     return junos_update_mod
 
 
 @pytest.fixture
-def mock_args(junos_update):
+def junos_upgrade():
+    """junos_ops.upgrade モジュールを返す"""
+    return junos_upgrade_mod
+
+
+@pytest.fixture
+def mock_args(junos_common):
     """テスト用の args グローバル変数を設定"""
-    junos_update.args = argparse.Namespace(
+    junos_common.args = argparse.Namespace(
         debug=False,
         dry_run=False,
         force=False,
+        config="config.ini",
+        list_format=None,
         copy=False,
         install=False,
         update=False,
         showversion=False,
         rollback=False,
         rebootat=None,
-        list_format=None,
-        config="config.ini",
+        specialhosts=[],
     )
-    return junos_update.args
+    return junos_common.args
 
 
 @pytest.fixture
-def mock_config(junos_update):
+def mock_config(junos_common):
     """テスト用の config グローバル変数を設定"""
     cfg = configparser.ConfigParser(allow_no_value=True)
     cfg.read_dict(
@@ -49,5 +64,5 @@ def mock_config(junos_update):
             "test-host": {"host": "192.0.2.1"},
         }
     )
-    junos_update.config = cfg
+    junos_common.config = cfg
     return cfg

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,38 +10,38 @@ import pytest
 class TestGetDefaultConfig:
     """get_default_config() のテスト"""
 
-    def test_current_dir(self, junos_update, tmp_path, monkeypatch):
+    def test_current_dir(self, junos_common, tmp_path, monkeypatch):
         """カレントディレクトリの config.ini を優先する"""
         (tmp_path / "config.ini").write_text("[DEFAULT]\n")
         monkeypatch.chdir(tmp_path)
-        result = junos_update.get_default_config()
+        result = junos_common.get_default_config()
         assert result == "config.ini"
 
-    def test_xdg_config_home(self, junos_update, tmp_path, monkeypatch):
+    def test_xdg_config_home(self, junos_common, tmp_path, monkeypatch):
         """XDG_CONFIG_HOME 配下の config.ini を検出する"""
         xdg_dir = tmp_path / "xdg" / "junos-ops"
         xdg_dir.mkdir(parents=True)
         (xdg_dir / "config.ini").write_text("[DEFAULT]\n")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path / "xdg")  # config.ini がないディレクトリ
-        result = junos_update.get_default_config()
+        result = junos_common.get_default_config()
         assert result == str(xdg_dir / "config.ini")
 
-    def test_fallback(self, junos_update, tmp_path, monkeypatch):
+    def test_fallback(self, junos_common, tmp_path, monkeypatch):
         """どこにも見つからない場合は config.ini を返す"""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        result = junos_update.get_default_config()
+        result = junos_common.get_default_config()
         assert result == "config.ini"
 
 
 class TestReadConfig:
     """read_config() のテスト"""
 
-    def test_valid_recipe(self, junos_update, mock_args, tmp_path):
+    def test_valid_config(self, junos_common, mock_args, tmp_path):
         """正常なINIファイルを読み込める"""
-        recipe = tmp_path / "test.ini"
-        recipe.write_text(
+        ini = tmp_path / "test.ini"
+        ini.write_text(
             "[DEFAULT]\n"
             "id = testuser\n"
             "port = 830\n"
@@ -51,100 +51,100 @@ class TestReadConfig:
             "[host2.example.jp]\n"
             "host = 192.0.2.1\n"
         )
-        junos_update.args.config = str(recipe)
-        result = junos_update.read_config()
+        junos_common.args.config = str(ini)
+        result = junos_common.read_config()
         assert result is False
-        assert junos_update.config.has_section("host1.example.jp")
-        assert junos_update.config.has_section("host2.example.jp")
+        assert junos_common.config.has_section("host1.example.jp")
+        assert junos_common.config.has_section("host2.example.jp")
 
-    def test_empty_recipe(self, junos_update, mock_args, tmp_path):
+    def test_empty_config(self, junos_common, mock_args, tmp_path):
         """空のINIファイルはエラー（True）を返す"""
-        recipe = tmp_path / "empty.ini"
-        recipe.write_text("")
-        junos_update.args.config = str(recipe)
-        result = junos_update.read_config()
+        ini = tmp_path / "empty.ini"
+        ini.write_text("")
+        junos_common.args.config = str(ini)
+        result = junos_common.read_config()
         assert result is True
 
-    def test_host_default_to_section_name(self, junos_update, mock_args, tmp_path):
+    def test_host_default_to_section_name(self, junos_common, mock_args, tmp_path):
         """hostキー省略時にセクション名がhostとして設定される"""
-        recipe = tmp_path / "test.ini"
-        recipe.write_text(
+        ini = tmp_path / "test.ini"
+        ini.write_text(
             "[DEFAULT]\nid = testuser\nport = 830\n\n"
             "[rt1.example.jp]\n"
         )
-        junos_update.args.config = str(recipe)
-        junos_update.read_config()
-        assert junos_update.config.get("rt1.example.jp", "host") == "rt1.example.jp"
+        junos_common.args.config = str(ini)
+        junos_common.read_config()
+        assert junos_common.config.get("rt1.example.jp", "host") == "rt1.example.jp"
 
-    def test_host_override(self, junos_update, mock_args, tmp_path):
+    def test_host_override(self, junos_common, mock_args, tmp_path):
         """hostキー指定時はその値が使われる"""
-        recipe = tmp_path / "test.ini"
-        recipe.write_text(
+        ini = tmp_path / "test.ini"
+        ini.write_text(
             "[DEFAULT]\nid = testuser\nport = 830\n\n"
             "[rt2.example.jp]\n"
             "host = 192.0.2.1\n"
         )
-        junos_update.args.config = str(recipe)
-        junos_update.read_config()
-        assert junos_update.config.get("rt2.example.jp", "host") == "192.0.2.1"
+        junos_common.args.config = str(ini)
+        junos_common.read_config()
+        assert junos_common.config.get("rt2.example.jp", "host") == "192.0.2.1"
 
 
 class TestGetModelFile:
     """get_model_file() のテスト"""
 
-    def test_found(self, junos_update, mock_config):
-        result = junos_update.get_model_file("test-host", "EX2300-24T")
+    def test_found(self, junos_upgrade, mock_config):
+        result = junos_upgrade.get_model_file("test-host", "EX2300-24T")
         assert result == "junos-arm-32-22.4R3-S6.5.tgz"
 
-    def test_not_found(self, junos_update, mock_config):
+    def test_not_found(self, junos_upgrade, mock_config):
         """存在しないモデルは例外を raise"""
         with pytest.raises(configparser.NoOptionError):
-            junos_update.get_model_file("test-host", "UNKNOWN_MODEL")
+            junos_upgrade.get_model_file("test-host", "UNKNOWN_MODEL")
 
-    def test_case_insensitive(self, junos_update, mock_config):
+    def test_case_insensitive(self, junos_upgrade, mock_config):
         """モデル名は小文字に変換される"""
-        result = junos_update.get_model_file("test-host", "ex2300-24t")
+        result = junos_upgrade.get_model_file("test-host", "ex2300-24t")
         assert result == "junos-arm-32-22.4R3-S6.5.tgz"
 
 
 class TestGetModelHash:
     """get_model_hash() のテスト"""
 
-    def test_found(self, junos_update, mock_config):
-        result = junos_update.get_model_hash("test-host", "EX2300-24T")
+    def test_found(self, junos_upgrade, mock_config):
+        result = junos_upgrade.get_model_hash("test-host", "EX2300-24T")
         assert result == "abc123def456"
 
-    def test_not_found(self, junos_update, mock_config):
+    def test_not_found(self, junos_upgrade, mock_config):
         """存在しないモデルは例外を raise"""
         with pytest.raises(configparser.NoOptionError):
-            junos_update.get_model_hash("test-host", "UNKNOWN_MODEL")
+            junos_upgrade.get_model_hash("test-host", "UNKNOWN_MODEL")
 
 
 class TestHashcache:
     """get_hashcache() / set_hashcache() のテスト"""
 
-    def test_set_and_get(self, junos_update, mock_config):
-        junos_update.set_hashcache("test-host", "testfile.tgz", "hash123")
-        result = junos_update.get_hashcache("test-host", "testfile.tgz")
+    def test_set_and_get(self, junos_upgrade, mock_config):
+        junos_upgrade.set_hashcache("test-host", "testfile.tgz", "hash123")
+        result = junos_upgrade.get_hashcache("test-host", "testfile.tgz")
         assert result == "hash123"
 
-    def test_get_nonexistent_section(self, junos_update, mock_config):
+    def test_get_nonexistent_section(self, junos_upgrade, mock_config):
         """存在しないセクションは None を返す"""
-        result = junos_update.get_hashcache("nonexistent-host", "file.tgz")
+        result = junos_upgrade.get_hashcache("nonexistent-host", "file.tgz")
         assert result is None
 
-    def test_get_nonexistent_option(self, junos_update, mock_config):
+    def test_get_nonexistent_option(self, junos_upgrade, mock_config):
         """存在しないオプションは None を返す"""
-        result = junos_update.get_hashcache("test-host", "nofile.tgz")
+        result = junos_upgrade.get_hashcache("test-host", "nofile.tgz")
         assert result is None
 
-    def test_set_creates_section(self, junos_update, mock_config):
+    def test_set_creates_section(self, junos_upgrade, mock_config):
         """存在しないセクションは自動作成される"""
-        junos_update.set_hashcache("new-host", "file.tgz", "hash456")
-        result = junos_update.get_hashcache("new-host", "file.tgz")
+        junos_upgrade.set_hashcache("new-host", "file.tgz", "hash456")
+        result = junos_upgrade.get_hashcache("new-host", "file.tgz")
         assert result == "hash456"
 
-    def test_thread_safety(self, junos_update, mock_config):
+    def test_thread_safety(self, junos_upgrade, mock_config):
         """複数スレッドからの同時アクセスでデータが壊れない"""
         errors = []
 
@@ -152,8 +152,8 @@ class TestHashcache:
             try:
                 host = f"thread-host-{host_id}"
                 for i in range(50):
-                    junos_update.set_hashcache(host, "file.tgz", f"hash-{host_id}-{i}")
-                    val = junos_update.get_hashcache(host, "file.tgz")
+                    junos_upgrade.set_hashcache(host, "file.tgz", f"hash-{host_id}-{i}")
+                    val = junos_upgrade.get_hashcache(host, "file.tgz")
                     if val is None:
                         errors.append(f"{host}: got None")
             except Exception as e:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -14,74 +14,74 @@ from jnpr.junos.exception import (
 class TestConnect:
     """connect() の接続テスト"""
 
-    def test_success(self, junos_update, mock_args, mock_config):
+    def test_success(self, junos_common, mock_args, mock_config):
         """正常接続"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is False
             assert dev is mock_dev
             mock_dev.open.assert_called_once()
 
-    def test_auth_error(self, junos_update, mock_args, mock_config):
+    def test_auth_error(self, junos_common, mock_args, mock_config):
         """認証エラー"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
             mock_dev.open.side_effect = ConnectAuthError(mock_dev)
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is True
             assert dev is None
 
-    def test_timeout_error(self, junos_update, mock_args, mock_config):
+    def test_timeout_error(self, junos_common, mock_args, mock_config):
         """接続タイムアウト"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
             mock_dev.open.side_effect = ConnectTimeoutError(mock_dev)
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is True
             assert dev is None
 
-    def test_refused_error(self, junos_update, mock_args, mock_config):
+    def test_refused_error(self, junos_common, mock_args, mock_config):
         """接続拒否"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
             mock_dev.open.side_effect = ConnectRefusedError(mock_dev)
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is True
             assert dev is None
 
-    def test_unknown_host_error(self, junos_update, mock_args, mock_config):
+    def test_unknown_host_error(self, junos_common, mock_args, mock_config):
         """不明なホスト"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
             mock_dev.open.side_effect = ConnectUnknownHostError(mock_dev)
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is True
             assert dev is None
 
-    def test_generic_exception(self, junos_update, mock_args, mock_config):
+    def test_generic_exception(self, junos_common, mock_args, mock_config):
         """その他の例外"""
-        with patch.object(junos_update, "Device") as MockDevice:
+        with patch.object(junos_common, "Device") as MockDevice:
             mock_dev = MagicMock()
             MockDevice.return_value = mock_dev
             mock_dev.open.side_effect = Exception("unexpected error")
 
-            err, dev = junos_update.connect("test-host")
+            err, dev = junos_common.connect("test-host")
 
             assert err is True
             assert dev is None

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,58 @@
+"""run_parallel() / get_targets() のテスト"""
+
+import argparse
+
+import pytest
+
+
+class TestRunParallel:
+    """run_parallel() のテスト"""
+
+    def test_serial(self, junos_common):
+        """max_workers=1 でシリアル実行"""
+        results = junos_common.run_parallel(lambda t: t.upper(), ["a", "b", "c"], max_workers=1)
+        assert results == {"a": "A", "b": "B", "c": "C"}
+
+    def test_parallel(self, junos_common):
+        """max_workers>1 で並列実行"""
+        results = junos_common.run_parallel(lambda t: t.upper(), ["a", "b", "c"], max_workers=3)
+        assert results == {"a": "A", "b": "B", "c": "C"}
+
+    def test_parallel_exception(self, junos_common):
+        """並列実行中の例外はエラーコード1を返す"""
+        def failing(t):
+            if t == "b":
+                raise RuntimeError("fail")
+            return 0
+
+        results = junos_common.run_parallel(failing, ["a", "b", "c"], max_workers=3)
+        assert results["a"] == 0
+        assert results["b"] == 1
+        assert results["c"] == 0
+
+    def test_empty_targets(self, junos_common):
+        """空のターゲットリスト"""
+        results = junos_common.run_parallel(lambda t: 0, [], max_workers=1)
+        assert results == {}
+
+
+class TestGetTargets:
+    """get_targets() のテスト"""
+
+    def test_all_sections(self, junos_common, mock_args, mock_config):
+        """specialhosts 未指定時は全セクションを返す"""
+        junos_common.args.specialhosts = []
+        targets = junos_common.get_targets()
+        assert targets == ["test-host"]
+
+    def test_specific_hosts(self, junos_common, mock_args, mock_config):
+        """specialhosts 指定時はそのリストを返す"""
+        junos_common.args.specialhosts = ["test-host"]
+        targets = junos_common.get_targets()
+        assert targets == ["test-host"]
+
+    def test_unknown_host_exits(self, junos_common, mock_args, mock_config):
+        """存在しないホスト指定時は sys.exit"""
+        junos_common.args.specialhosts = ["unknown-host"]
+        with pytest.raises(SystemExit):
+            junos_common.get_targets()

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -1,0 +1,207 @@
+"""RSI/SCF 収集のテスト"""
+
+from unittest.mock import patch, MagicMock, mock_open
+from lxml import etree
+
+from junos_ops import rsi
+
+
+class TestGetSupportInformation:
+    """get_support_information() のテスト"""
+
+    def test_default_timeout(self):
+        """通常機種は timeout=600"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-mx",
+            "srx_cluster": None,
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=600
+        )
+
+    def test_srx_branch_timeout(self):
+        """SRX_BRANCH は timeout=1200"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "SRX_BRANCH",
+            "model": "SRX345",
+            "model_info": {"SRX345": {}},
+            "hostname": "test-srx",
+            "srx_cluster": None,
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=1200
+        )
+
+    def test_ex2300_timeout(self):
+        """EX2300-24T は timeout=1200"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "SWITCH",
+            "model": "EX2300-24T",
+            "model_info": {"EX2300-24T": {}},
+            "hostname": "test-ex",
+            "srx_cluster": None,
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=1200
+        )
+
+    def test_virtual_chassis_timeout(self):
+        """Virtual Chassis (model_info >= 2) は timeout=1800"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "SWITCH",
+            "model": "EX4300-48T",
+            "model_info": {"EX4300-48T": {}, "EX4300-48T-2": {}},
+            "hostname": "test-vc",
+            "srx_cluster": None,
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=1800
+        )
+
+    def test_qfx5110_timeout(self):
+        """QFX5110-48S-4C は timeout=2400"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "SWITCH",
+            "model": "QFX5110-48S-4C",
+            "model_info": {"QFX5110-48S-4C": {}, "QFX5110-48S-4C-2": {}},
+            "hostname": "test-qfx",
+            "srx_cluster": None,
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=2400
+        )
+
+    def test_srx_cluster_node_primary(self):
+        """SRX cluster の場合は node='primary' を指定"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "SRX_HIGHEND",
+            "model": "SRX4600",
+            "model_info": {"SRX4600": {}},
+            "hostname": "test-cluster",
+            "srx_cluster": "True",
+        }
+        rsi.get_support_information(dev)
+        dev.rpc.get_support_information.assert_called_once_with(
+            {"format": "text"}, dev_timeout=600, node="primary"
+        )
+
+    def test_exception_returns_none(self):
+        """例外発生時は None を返す"""
+        dev = MagicMock()
+        dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-err",
+            "srx_cluster": None,
+        }
+        dev.rpc.get_support_information.side_effect = Exception("RPC failed")
+        result = rsi.get_support_information(dev)
+        assert result is None
+
+
+class TestCmdRsi:
+    """cmd_rsi() のテスト"""
+
+    def test_connect_fail(self, junos_common, mock_args, mock_config):
+        """接続失敗時に 1 を返す"""
+        with patch.object(rsi.common, "connect", return_value=(True, None)):
+            result = rsi.cmd_rsi("test-host")
+            assert result == 1
+
+    def test_success(self, junos_common, mock_args, mock_config, tmp_path):
+        """正常時にSCFとRSIファイルが書き出される"""
+        mock_config.set("test-host", "RSI_DIR", str(tmp_path) + "/")
+        mock_dev = MagicMock()
+        mock_dev.cli.return_value = "  set system host-name test  \n"
+        rsi_xml = etree.Element("output")
+        rsi_xml.text = "  RSI output text  \n"
+        mock_dev.rpc.get_support_information.return_value = rsi_xml
+        mock_dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-host",
+            "srx_cluster": None,
+        }
+
+        with patch.object(rsi.common, "connect", return_value=(False, mock_dev)):
+            result = rsi.cmd_rsi("test-host")
+
+        assert result == 0
+        scf = (tmp_path / "test-host.SCF").read_text()
+        assert scf == "set system host-name test"
+        rsi_content = (tmp_path / "test-host.RSI").read_text()
+        assert rsi_content == "RSI output text"
+        mock_dev.close.assert_called_once()
+
+    def test_rsi_failure(self, junos_common, mock_args, mock_config, tmp_path):
+        """get_support_information 失敗時に 2 を返す"""
+        mock_config.set("test-host", "RSI_DIR", str(tmp_path) + "/")
+        mock_dev = MagicMock()
+        mock_dev.cli.return_value = "config output"
+        mock_dev.rpc.get_support_information.side_effect = Exception("timeout")
+        mock_dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-host",
+            "srx_cluster": None,
+        }
+
+        with patch.object(rsi.common, "connect", return_value=(False, mock_dev)):
+            result = rsi.cmd_rsi("test-host")
+
+        assert result == 2
+        mock_dev.close.assert_called_once()
+
+    def test_dev_close_on_exception(self, junos_common, mock_args, mock_config):
+        """例外時でも dev.close() が呼ばれる"""
+        mock_dev = MagicMock()
+        mock_dev.cli.side_effect = Exception("unexpected")
+        mock_dev.facts = {}
+
+        with patch.object(rsi.common, "connect", return_value=(False, mock_dev)):
+            result = rsi.cmd_rsi("test-host")
+
+        assert result == 1
+        mock_dev.close.assert_called_once()
+
+    def test_default_rsi_dir(self, junos_common, mock_args, mock_config):
+        """RSI_DIR 未設定時は ./ がデフォルト"""
+        mock_dev = MagicMock()
+        mock_dev.cli.return_value = "config"
+        rsi_xml = etree.Element("output")
+        rsi_xml.text = "RSI text"
+        mock_dev.rpc.get_support_information.return_value = rsi_xml
+        mock_dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-host",
+            "srx_cluster": None,
+        }
+
+        m = mock_open()
+        with patch.object(rsi.common, "connect", return_value=(False, mock_dev)):
+            with patch("builtins.open", m):
+                result = rsi.cmd_rsi("test-host")
+
+        assert result == 0
+        # デフォルト ./ が使われている
+        m.assert_any_call("./test-host.SCF", mode="w")
+        m.assert_any_call("./test-host.RSI", mode="w")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,74 +10,74 @@ import pytest
 class TestCompareVersion:
     """compare_version() のテスト"""
 
-    def test_greater(self, junos_update, mock_args):
-        assert junos_update.compare_version("22.4R3-S6", "22.4R3-S5") == 1
+    def test_greater(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("22.4R3-S6", "22.4R3-S5") == 1
 
-    def test_less(self, junos_update, mock_args):
-        assert junos_update.compare_version("18.4R3-S9", "18.4R3-S10") == -1
+    def test_less(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("18.4R3-S9", "18.4R3-S10") == -1
 
-    def test_equal(self, junos_update, mock_args):
-        assert junos_update.compare_version("22.4R3-S6", "22.4R3-S6") == 0
+    def test_equal(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("22.4R3-S6", "22.4R3-S6") == 0
 
-    def test_none_left(self, junos_update, mock_args):
-        assert junos_update.compare_version(None, "22.4R3-S6") is None
+    def test_none_left(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version(None, "22.4R3-S6") is None
 
-    def test_none_right(self, junos_update, mock_args):
-        assert junos_update.compare_version("22.4R3-S6", None) is None
+    def test_none_right(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("22.4R3-S6", None) is None
 
-    def test_both_none(self, junos_update, mock_args):
-        assert junos_update.compare_version(None, None) is None
+    def test_both_none(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version(None, None) is None
 
-    def test_major_version_diff(self, junos_update, mock_args):
-        assert junos_update.compare_version("22.4R3-S6", "18.4R3-S10") == 1
+    def test_major_version_diff(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("22.4R3-S6", "18.4R3-S10") == 1
 
-    def test_minor_version_diff(self, junos_update, mock_args):
-        assert junos_update.compare_version("22.2R1", "22.4R1") == -1
+    def test_minor_version_diff(self, junos_upgrade, mock_args):
+        assert junos_upgrade.compare_version("22.2R1", "22.4R1") == -1
 
 
 class TestYymmddhhmmType:
     """yymmddhhmm_type() のテスト"""
 
-    def test_valid(self, junos_update):
-        result = junos_update.yymmddhhmm_type("2501020304")
+    def test_valid(self, junos_upgrade):
+        result = junos_upgrade.yymmddhhmm_type("2501020304")
         assert result == datetime.datetime(2025, 1, 2, 3, 4)
 
-    def test_year_end(self, junos_update):
-        result = junos_update.yymmddhhmm_type("2512311959")
+    def test_year_end(self, junos_upgrade):
+        result = junos_upgrade.yymmddhhmm_type("2512311959")
         assert result == datetime.datetime(2025, 12, 31, 19, 59)
 
-    def test_invalid_format(self, junos_update):
+    def test_invalid_format(self, junos_upgrade):
         with pytest.raises(argparse.ArgumentTypeError):
-            junos_update.yymmddhhmm_type("invalid")
+            junos_upgrade.yymmddhhmm_type("invalid")
 
-    def test_empty_string(self, junos_update):
+    def test_empty_string(self, junos_upgrade):
         with pytest.raises(argparse.ArgumentTypeError):
-            junos_update.yymmddhhmm_type("")
+            junos_upgrade.yymmddhhmm_type("")
 
 
 class TestGetPlanningVersion:
     """get_planning_version() のテスト"""
 
-    def test_normal(self, junos_update, mock_args, mock_config):
+    def test_normal(self, junos_upgrade, mock_args, mock_config):
         dev = MagicMock()
         dev.facts = {"model": "EX2300-24T"}
-        result = junos_update.get_planning_version("test-host", dev)
+        result = junos_upgrade.get_planning_version("test-host", dev)
         assert result == "22.4R3-S6.5"
 
-    def test_different_format(self, junos_update, mock_args, mock_config):
+    def test_different_format(self, junos_upgrade, mock_args, mock_config):
         """SRX系のファイル名からもバージョン抽出できる"""
         mock_config.set("DEFAULT", "srx345.file", "junos-srxsme-15.1X49-D240.tgz")
         mock_config.set("DEFAULT", "srx345.hash", "dummy")
         dev = MagicMock()
         dev.facts = {"model": "SRX345"}
-        result = junos_update.get_planning_version("test-host", dev)
+        result = junos_upgrade.get_planning_version("test-host", dev)
         assert result == "15.1X49-D240"
 
-    def test_no_match(self, junos_update, mock_args, mock_config):
+    def test_no_match(self, junos_upgrade, mock_args, mock_config):
         """正規表現にマッチしないファイル名の場合 None"""
         mock_config.set("DEFAULT", "srx345.file", "noversion.tgz")
         mock_config.set("DEFAULT", "srx345.hash", "dummy")
         dev = MagicMock()
         dev.facts = {"model": "SRX345"}
-        result = junos_update.get_planning_version("test-host", dev)
+        result = junos_upgrade.get_planning_version("test-host", dev)
         assert result is None


### PR DESCRIPTION
## Summary

- cli.py をモジュール分割: `common.py`（共通機能）、`upgrade.py`（パッケージ操作）、`rsi.py`（RSI/SCF収集）
- argparse サブコマンド方式に移行: `upgrade`/`copy`/`install`/`rollback`/`version`/`reboot`/`ls`/`rsi`
- junos-rsi.py を `rsi` サブコマンドとして統合（ThreadPoolExecutor による並列実行対応）
- `-V` → `--version`、共通オプション: `-c`/`-n`/`-d`/`--force`/`--workers N`
- バージョン 0.3 → 0.4

## 変更ファイル

| 操作 | ファイル |
|------|---------|
| 新規 | `junos_ops/common.py`（共通機能: 設定読込、接続管理、並列実行） |
| 新規 | `junos_ops/upgrade.py`（パッケージ操作: 20関数を移動） |
| 新規 | `junos_ops/rsi.py`（RSI/SCF収集） |
| 書換 | `junos_ops/cli.py`（サブコマンドルーティング層に縮小） |
| 変更 | `junos_ops/__init__.py`（v0.4） |
| 変更 | `tests/conftest.py`、`test_config.py`、`test_connect.py`、`test_version.py` |
| 新規 | `tests/test_parallel.py`、`tests/test_rsi.py` |
| 変更 | `README.md`、`CLAUDE.md`、`config.ini` |

## Test plan

- [x] `pytest tests/ -v --tb=short` — 67 tests all passed
- [x] `junos-ops --version` → `junos-ops 0.4`
- [x] `junos-ops --help` — サブコマンド一覧表示
- [x] `junos-ops upgrade --help` — 共通オプション表示
- [x] `junos-ops rsi --help` — rsi固有オプション表示
- [ ] 実機テスト: `junos-ops upgrade -n hostname`
- [ ] 実機テスト: `junos-ops rsi hostname`

🤖 Generated with [Claude Code](https://claude.com/claude-code)