### PR TITLE
feat: EX/QFXシリーズのコピー前にスナップショット自動削除 (#5)

### DIFF
--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -38,6 +38,7 @@ from junos_ops import upgrade
 from junos_ops import rsi
 
 # upgrade モジュールの関数への参照（後方互換）
+delete_snapshots = upgrade.delete_snapshots
 copy = upgrade.copy
 rollback = upgrade.rollback
 clear_reboot = upgrade.clear_reboot


### PR DESCRIPTION
## Summary

- EX/QFXシリーズ（personality=SWITCH）のパッケージコピー前に `request system snapshot delete *` を自動実行
- `copy()` 内の storage cleanup 直後に `delete_snapshots(dev)` を呼び出す
- 削除失敗は致命的でないため警告のみで続行（容量不足は後続の SCP で検出される）

## 新規関数

- `delete_snapshots(dev)` — personality=SWITCH の場合のみ `dev.rpc.request_snapshot(delete="*")` を実行

## Test plan

- [x] 既存85テスト + 新規4テスト = 全89テスト PASS
- [ ] CI通過確認

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)