### PR TITLE
feat: 汎用 config サブコマンドを追加

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,8 @@ def mock_args(junos_common):
         showversion=False,
         rollback=False,
         rebootat=None,
+        configfile=None,
+        confirm_timeout=1,
         specialhosts=[],
     )
     return junos_common.args

--- a/tests/test_config_push.py
+++ b/tests/test_config_push.py
@@ -1,0 +1,112 @@
+"""load_config() のテスト"""
+
+from unittest.mock import MagicMock, patch, call
+
+
+class TestLoadConfig:
+    """load_config() のテスト"""
+
+    def test_success(self, junos_upgrade, mock_args, mock_config):
+        """正常系: load → diff → commit_check → commit confirmed → confirm"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system ..."
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is False
+        mock_cu.lock.assert_called_once()
+        mock_cu.load.assert_called_once_with(path="commands.set", format="set")
+        mock_cu.diff.assert_called_once()
+        mock_cu.pdiff.assert_called_once()
+        mock_cu.commit_check.assert_called_once()
+        # commit confirmed 1 → commit で確定
+        assert mock_cu.commit.call_count == 2
+        mock_cu.commit.assert_any_call(confirm=1)
+        mock_cu.commit.assert_any_call()
+        mock_cu.unlock.assert_called_once()
+
+    def test_no_changes(self, junos_upgrade, mock_args, mock_config):
+        """差分なし → "no changes" で正常終了"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = None
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is False
+        mock_cu.lock.assert_called_once()
+        mock_cu.load.assert_called_once()
+        mock_cu.commit.assert_not_called()
+        mock_cu.unlock.assert_called_once()
+
+    def test_dry_run(self, junos_upgrade, mock_args, mock_config):
+        """dry-run: diff 表示のみ、commit しない"""
+        mock_args.dry_run = True
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system ..."
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is False
+        mock_cu.pdiff.assert_called_once()
+        mock_cu.commit.assert_not_called()
+        mock_cu.rollback.assert_called_once()
+        mock_cu.unlock.assert_called_once()
+
+    def test_commit_check_fail(self, junos_upgrade, mock_args, mock_config):
+        """commit_check 失敗 → rollback + unlock"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system ..."
+        mock_cu.commit_check.side_effect = Exception("commit check failed")
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is True
+        mock_cu.rollback.assert_called_once()
+        mock_cu.unlock.assert_called_once()
+        mock_cu.commit.assert_not_called()
+
+    def test_commit_fail(self, junos_upgrade, mock_args, mock_config):
+        """commit 失敗 → rollback + unlock"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system ..."
+        mock_cu.commit.side_effect = Exception("commit failed")
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is True
+        mock_cu.rollback.assert_called_once()
+        mock_cu.unlock.assert_called_once()
+
+    def test_load_error(self, junos_upgrade, mock_args, mock_config):
+        """ファイル読み込みエラー → rollback + unlock"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.load.side_effect = Exception("file not found")
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is True
+        mock_cu.rollback.assert_called_once()
+        mock_cu.unlock.assert_called_once()
+        mock_cu.commit.assert_not_called()
+
+    def test_lock_error(self, junos_upgrade, mock_args, mock_config):
+        """ロック取得失敗"""
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.lock.side_effect = Exception("lock failed")
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is True
+        mock_cu.load.assert_not_called()
+        mock_cu.commit.assert_not_called()
+
+    def test_custom_confirm_timeout(self, junos_upgrade, mock_args, mock_config):
+        """confirm_timeout カスタム値"""
+        mock_args.confirm_timeout = 3
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system ..."
+        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+            result = junos_upgrade.load_config("test-host", dev, "commands.set")
+        assert result is False
+        mock_cu.commit.assert_any_call(confirm=3)


### PR DESCRIPTION
## Summary

- `junos-ops config -f commands.set [hostname ...]` で set コマンドファイルを複数デバイスに展開
- 安全なコミットフロー: lock → load → diff → commit_check → commit confirmed → confirm → unlock
- dry-run 対応（diff 表示のみ、commit しない）
- `--confirm N` で commit confirm タイムアウト指定可能（デフォルト 1分）
- エラー時は rollback + unlock で自動クリーンアップ

## Test plan

- [x] load_config 正常系（lock → load → diff → commit_check → commit confirmed → confirm）
- [x] 差分なし → "no changes" で正常終了
- [x] dry-run: diff 表示のみ、commit しない
- [x] commit_check 失敗 → rollback + unlock
- [x] commit 失敗 → rollback + unlock
- [x] ファイル読み込みエラー → rollback + unlock
- [x] ロック取得失敗
- [x] confirm_timeout カスタム値
- [x] 全 97 テスト PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)