### PR TITLE
chore: pyproject.toml メタデータ拡充と CI にビルドテスト追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v --tb=short
+
+      - name: Build package
+        run: pip install build && python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,33 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "junos-ops"
 dynamic = ["version"]
-description = "Juniper Networks デバイス運用ツール"
+description = "Automated JUNOS package management tool for Juniper Networks devices"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.12"
+authors = [
+    {name = "AIKAWA Shigechika"},
+]
+keywords = ["juniper", "junos", "netconf", "pyez", "network", "automation"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: System :: Networking",
+    "Topic :: System :: Systems Administration",
+]
 dependencies = [
     "junos-eznc",
     "looseversion",
 ]
+
+[project.urls]
+Homepage = "https://github.com/shigechika/junos-ops"
+Repository = "https://github.com/shigechika/junos-ops"
+Issues = "https://github.com/shigechika/junos-ops/issues"
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]


### PR DESCRIPTION
## Summary
- PyPI公開に向けて pyproject.toml に authors, classifiers, keywords, urls を追加
- PEP 639 の license expression と競合する License classifier を削除
- CI にパッケージビルド検証ステップ (`python -m build`) を追加

## Test plan
- [x] `python -m build` で sdist / wheel が正常生成されることを確認済み
- [x] `pytest tests/ -v` で 97テスト全パス確認済み
- [ ] CI (GitHub Actions) でビルドステップが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)