### PR TITLE
feat: add check subcommand for pre-flight verification (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `upgrade.check_local_package_by_model(hostname, model)` — device-less local checksum helper. Uses `hashlib` directly (no PyEZ `SW` dependency). The existing `check_local_package(hostname, dev)` is now a thin wrapper that resolves the model from `dev.facts` and delegates to this new core.
 - `upgrade.check_remote_package_by_model(hostname, dev, model)` — companion by-model variant for remote checks (same semantics, model supplied by caller).
 - `display.format_check_table(rows, *, show_connect, show_local, show_remote)` / `print_check_table(...)` — table renderer shared by the CLI and any non-CLI caller (e.g. future junos-mcp tool).
+- `display.format_check_local_inventory(rows)` / `print_check_local_inventory(rows)` — table renderer for inventory mode (collapses shared `lpath` into a single header line).
+- Optional `[progress]` extra (`pip install junos-ops[progress]`) installs `tqdm` so per-host check runs show a live progress bar plus per-host status lines as workers complete. Falls back silently to plain output when tqdm is missing or stderr is not a TTY.
+
+### Performance
+- `check --connect` no longer pays for PyEZ's full facts collection (~10 RPCs per host: `show version`, `get-chassis-cluster-status`, `file-show /etc/hosts.junos`, `get-interface-information __juniper_private1__`, …). The connect path now opens with `gather_facts=False` and fetches only the model field via a single `get-software-information` RPC (~100 ms vs ~5–10 s per host).
+- `common.connect()` learned a `gather_facts` kwarg (default True for backward compatibility) and an `auto_probe` kwarg (default 0; check passes 5 to fail unreachable hosts at the TCP layer in ~5 s instead of waiting the OS-default 60–120 s SYN timeout).
+- Default `--workers` for `check` is 20 (was 1), matching `rsi`. ~90-host runs go from ~20 minutes serial to ~30 seconds.
+
+### Fixed
+- Without a `logging.ini` the fallback `basicConfig(level=INFO)` was flooding stdout with every NETCONF/SSH frame from `ncclient` / `paramiko` / `junos-eznc`. Those three loggers are now pinned to WARNING in the fallback path; users with a custom `logging.ini` are unaffected.
 
 ## [0.14.1] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-14
+
+### Added
+- **`check` subcommand ([#41](https://github.com/shigechika/junos-ops/issues/41)): unified pre-flight verification across NETCONF reachability and firmware hash.** Sub-flags: `--connect` (NETCONF + facts probe), `--local` (local firmware checksum, no NETCONF required), `--remote` (device-side checksum, confirms SCP copy completed), `--all` (shorthand for all three). Output is an aligned table with one row per host; exit code is non-zero if any host has `fail` / `bad` / `missing` / `error`. Default (no flag) is `--connect` — fills the previously-awkward "just verify reachability" gap.
+  - `--model MODEL` override, or optional `model = MX5-T` key per host in `config.ini`, so `--local` works entirely offline against a staging server.
+  - Model resolution order: `--model` > `config.ini` `[host].model` > `dev.facts["model"]` (only when connected).
+- `upgrade.check_local_package_by_model(hostname, model)` — device-less local checksum helper. Uses `hashlib` directly (no PyEZ `SW` dependency). The existing `check_local_package(hostname, dev)` is now a thin wrapper that resolves the model from `dev.facts` and delegates to this new core.
+- `upgrade.check_remote_package_by_model(hostname, dev, model)` — companion by-model variant for remote checks (same semantics, model supplied by caller).
+- `display.format_check_table(rows, *, show_connect, show_local, show_remote)` / `print_check_table(...)` — table renderer shared by the CLI and any non-CLI caller (e.g. future junos-mcp tool).
+
 ## [0.14.1] - 2026-04-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.15.0] - 2026-04-14
 
 ### Added
-- **`check` subcommand ([#41](https://github.com/shigechika/junos-ops/issues/41)): unified pre-flight verification across NETCONF reachability and firmware hash.** Sub-flags: `--connect` (NETCONF + facts probe), `--local` (local firmware checksum, no NETCONF required), `--remote` (device-side checksum, confirms SCP copy completed), `--all` (shorthand for all three). Output is an aligned table with one row per host; exit code is non-zero if any host has `fail` / `bad` / `missing` / `error`. Default (no flag) is `--connect` — fills the previously-awkward "just verify reachability" gap.
-  - `--model MODEL` override, or optional `model = MX5-T` key per host in `config.ini`, so `--local` works entirely offline against a staging server.
-  - Model resolution order: `--model` > `config.ini` `[host].model` > `dev.facts["model"]` (only when connected).
+- **`check` subcommand ([#41](https://github.com/shigechika/junos-ops/issues/41)): unified pre-flight verification across NETCONF reachability and firmware hash.**
+  - `--local` is **inventory-based** and ignores hostnames — it iterates every `<model>.file` / `<model>.hash` pair in `config.ini` and verifies the files on the staging server. No NETCONF connection required. `--model M` restricts the inventory to a single model.
+  - `--connect` (NETCONF + facts probe) and `--remote` (device-side checksum, doubles as SCP copy verification) are **per-host** and use the supplied hostnames or `--tags` filter.
+  - `--all` runs both modes: the inventory table is printed first, then the per-host table.
+  - Default (no flag) is `--connect` — fills the previously-awkward "just verify reachability" gap.
+  - Exit code is non-zero if any row has `fail` / `bad` / `missing` / `error`.
+  - Model resolution for per-host checks: `--model` > `config.ini` `[host].model` (new optional key) > `dev.facts["model"]` (only when connected).
 - `upgrade.check_local_package_by_model(hostname, model)` — device-less local checksum helper. Uses `hashlib` directly (no PyEZ `SW` dependency). The existing `check_local_package(hostname, dev)` is now a thin wrapper that resolves the model from `dev.facts` and delegates to this new core.
 - `upgrade.check_remote_package_by_model(hostname, dev, model)` — companion by-model variant for remote checks (same semantics, model supplied by caller).
 - `display.format_check_table(rows, *, show_connect, show_local, show_remote)` / `print_check_table(...)` — table renderer shared by the CLI and any non-CLI caller (e.g. future junos-mcp tool).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,9 @@ LICENSE
 - `get_rescue_config_time()` — rescue config ファイルの更新時刻取得
 - `check_and_reinstall()` — config変更検出＋validation付き自動再インストール（dict）
 - `check_running_package()` — running とパッケージ名を突き合わせ（dict: running/expected_file/match）
+- `check_local_package(hostname, dev)` / `check_local_package_by_model(hostname, model)` — ローカル firmware checksum 検証（後者は hashlib 直接、NETCONF 不要）
+- `check_remote_package(hostname, dev)` / `check_remote_package_by_model(hostname, dev, model)` — リモート firmware checksum 検証（by_model 版はモデルを明示指定）
+- `_compute_local_checksum(path, algo)` — hashlib ベースの純粋関数（PyEZ SW 非依存）
 - `get_hashcache()` / `set_hashcache()` — チェックサムキャッシュ（スレッド安全）
 - `load_config()` — set コマンドファイルのロード＋コミット（dict: steps + logger.info でリアルタイム進捗）
 - `list_remote_path()` — リモートファイル一覧（dict: files/file_count/format）
@@ -91,6 +94,7 @@ LICENSE
 ### cli.py — サブコマンドルーティング
 - `main()` — argparse サブコマンド定義、ディスパッチ
 - `cmd_upgrade()`, `cmd_copy()`, `cmd_install()`, `cmd_rollback()`, `cmd_version()`, `cmd_reboot()`, `cmd_ls()`, `cmd_show()`, `cmd_config()`, `cmd_facts()` — サブコマンド用エントリ関数（connect → header → core(dict) → display）
+- `_check_host(hostname)` — `check` サブコマンド用ワーカー。int ではなく dict を返し、`main()` で結果を集約して `display.print_check_table` にテーブル出力。モデル解決順: `--model` > `config.ini [host].model` > `dev.facts["model"]`
 - `_open_connection()` — NETCONF 接続＋エラー時の display 出力ヘルパー
 
 ## CLI設計
@@ -105,6 +109,7 @@ junos-ops reboot --at YYMMDDHHMM [hostname ...]  # リブート
 junos-ops ls [-l] [hostname ...]           # リモートファイル一覧
 junos-ops show COMMAND [hostname ...]           # 任意の CLI コマンドを実行
 junos-ops config -f FILE [--confirm N] [hostname ...]  # set コマンドファイル適用
+junos-ops check [--connect|--local|--remote|--all] [--model M] [hostname ...]  # pre-flight チェック
 junos-ops rsi [hostname ...]               # RSI/SCF収集
 junos-ops [hostname ...]                   # サブコマンド省略 → device facts 表示
 junos-ops --version                        # プログラムバージョン

--- a/README.ja.md
+++ b/README.ja.md
@@ -380,19 +380,39 @@ rt1.example.jp: software validate package-result: 0
 
 ### check（Pre-flight 検証）
 
-NETCONF 疎通、ローカル/リモートの firmware ハッシュを 1 コマンドで一括検証し、整形テーブルで出力します。1 件でも失敗すると終了コードが非ゼロになります。フラグ未指定時のデフォルトは `--connect` のみ。
+NETCONF 疎通、ローカル/リモートの firmware ハッシュを 1 コマンドで一括検証します。1 件でも失敗すると終了コードが非ゼロになります。フラグ未指定時のデフォルトは `--connect` のみ。
+
+`--local` は **インベントリモード** で、ホスト名は無視されます。`config.ini` に記載された `<model>.file` / `<model>.hash` のペアを列挙してステージングサーバー上のファイルを検証するので、NETCONF 接続は一切不要です:
 
 ```
-% junos-ops check --all rt1.example.jp rt2.example.jp
-hostname         connect  local       remote      model     file
----------------  -------  ----------  ----------  --------  -----------------------------------
-rt1.example.jp   ok       ok(cached)  ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
-rt2.example.jp   ok       ok          missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+% junos-ops check --local
+model            file                                                        status      local_file
+---------------  ----------------------------------------------------------  ----------  ----------------------------------------------------------------------
+ex2300-24t       junos-arm-32-23.4R2-S7.4.tgz                                ok          /opt/firmware/junos-arm-32-23.4R2-S7.4.tgz
+ex3400-24t       junos-arm-32-23.4R2-S7.4.tgz                                ok(cached)  /opt/firmware/junos-arm-32-23.4R2-S7.4.tgz
+ex4300-32f       jinstall-ex-4300-21.4R3-S12.2-signed.tgz                    ok          /opt/firmware/jinstall-ex-4300-21.4R3-S12.2-signed.tgz
+mx5-t            jinstall-ppc-21.2R3-S8.5-signed.tgz                         missing     /opt/firmware/jinstall-ppc-21.2R3-S8.5-signed.tgz
+
+  mx5-t: - local package: /opt/firmware/jinstall-ppc-21.2R3-S8.5-signed.tgz is not found.
+```
+
+`--model M` で特定モデルだけに絞り込むことも可能です。
+
+`--connect` / `--remote`（および `--all`）は **ホスト単位** で、指定されたホスト（または `config.ini` 内の全ホスト、`--tags` でフィルタ可能）に対して動作します。`--remote` は `copy` 完了後・`install` 前の「SCP が最後まで落ちたか」確認としても使えます:
+
+```
+% junos-ops check --connect --remote rt1.example.jp rt2.example.jp
+hostname         connect  remote      model     file
+---------------  -------  ----------  --------  -----------------------------------
+rt1.example.jp   ok       ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+rt2.example.jp   ok       missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
 
   rt2.example.jp: remote: - remote package: jinstall-ppc-18.4R3-S10-signed.tgz is not found.
 ```
 
-`--local` は NETCONF 接続なしで動作するため、大量展開前のステージングサーバー上での firmware 棚卸しに使えます。モデルは `--model MX5-T` で指定するか、`config.ini` の各ホストセクションに `model = MX5-T` を追記します。`--remote` は `copy` 完了後・`install` 前の SCP 完走チェックとしても機能します。
+`--connect` / `--remote` でモデルが必要な場面では、`--model` 引数、`config.ini` の host セクションの `model = MX5-T` キー、デバイスから取得した `facts["model"]` の順にフォールバックします。
+
+`--all` は両方のテーブルを順に出力します（先にインベントリ、次にホスト別）。
 
 ### rsi（RSI/SCF並列収集）
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,6 +18,7 @@ Juniper/JUNOS デバイスの運用を NETCONF 経由で自動化する Python C
 - ロールバック対応（MX/EX/SRX モデル別処理）
 - スケジュールリブート（ファームウェアインストール後の config 変更を自動検出し、必要なら再インストール）
 - RSI（request support information）/ SCF（show configuration | display set）の並列収集
+- Pre-flight `check` サブコマンド: NETCONF 疎通・ローカル firmware ハッシュ（デバイス接続不要）・リモート firmware ハッシュを 1 コマンドで統合表示
 - 任意の CLI コマンドを複数ホストで実行（`show` サブコマンド、`RpcTimeoutError` 自動リトライ対応）
 - `config` での設定投入（commit confirmed + コミット後ヘルスチェック: ping / `uptime` NETCONF プローブ / 任意の CLI コマンド）
 - Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.md#日本語版)）
@@ -186,6 +187,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `reboot --at YYMMDDHHMM` | 指定日時にリブートをスケジュール |
 | `ls [-l]` | リモートパスのファイル一覧 |
 | `show COMMAND [--retry N]` / `show -f FILE` | 任意の CLI コマンド（またはコマンドファイル）を複数ホストで実行 |
+| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight チェック: NETCONF 疎通・ローカル/リモート firmware ハッシュ |
 | `config -f FILE` | set コマンドファイルを適用（`--confirm` / `--timeout` / `--no-confirm` / `--health-check` / `--no-health-check` の詳細は [docs/config.md](docs/config.md) を参照） |
 | `rsi` | RSI/SCF を並列収集 |
 | （なし） | デバイスファクト（device facts）を表示 |
@@ -375,6 +377,22 @@ rt1.example.jp: software validate package-result: 0
     - running='18.4R3-S7.2' < pending='18.4R3-S10' : Please plan to reboot.
   - reboot requested by exadmin at Sat Dec  4 05:00:00 2021
 ```
+
+### check（Pre-flight 検証）
+
+NETCONF 疎通、ローカル/リモートの firmware ハッシュを 1 コマンドで一括検証し、整形テーブルで出力します。1 件でも失敗すると終了コードが非ゼロになります。フラグ未指定時のデフォルトは `--connect` のみ。
+
+```
+% junos-ops check --all rt1.example.jp rt2.example.jp
+hostname         connect  local       remote      model     file
+---------------  -------  ----------  ----------  --------  -----------------------------------
+rt1.example.jp   ok       ok(cached)  ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+rt2.example.jp   ok       ok          missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+
+  rt2.example.jp: remote: - remote package: jinstall-ppc-18.4R3-S10-signed.tgz is not found.
+```
+
+`--local` は NETCONF 接続なしで動作するため、大量展開前のステージングサーバー上での firmware 棚卸しに使えます。モデルは `--model MX5-T` で指定するか、`config.ini` の各ホストセクションに `model = MX5-T` を追記します。`--remote` は `copy` 完了後・`install` 前の SCP 完走チェックとしても機能します。
 
 ### rsi（RSI/SCF並列収集）
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Python CLI to automate Juniper/JUNOS operations over NETCONF: model-aware upgr
 - Rollback support (model-specific handling for MX/EX/SRX)
 - Scheduled reboot with automatic config-drift detection and re-install
 - Parallel RSI (request support information) / SCF (show configuration | display set) collection
+- Pre-flight `check` subcommand: NETCONF reachability, local firmware hash (device-less), and remote firmware hash in one unified table
 - Arbitrary CLI command execution across hosts (`show`) with `RpcTimeoutError` retry
 - Configuration push with `commit confirmed` safety and post-commit health checks (ping, `uptime` NETCONF probe, or any CLI command)
 - Jinja2 template support for per-host configuration generation ([details](docs/template.md))
@@ -186,6 +187,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `reboot --at YYMMDDHHMM` | Schedule a reboot at the specified time |
 | `ls [-l]` | List files on the remote path |
 | `show COMMAND [--retry N]` / `show -f FILE` | Run an arbitrary CLI command (or file of commands) across devices |
+| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight checks: NETCONF reachability, local/remote firmware hash |
 | `config -f FILE` | Push a set command file (see [docs/config.md](docs/config.md) for `--confirm`, `--timeout`, `--no-confirm`, `--health-check`, `--no-health-check`) |
 | `rsi` | Collect RSI/SCF in parallel |
 | (none) | Show device facts |
@@ -375,6 +377,22 @@ rt1.example.jp: software validate package-result: 0
     - running='18.4R3-S7.2' < pending='18.4R3-S10' : Please plan to reboot.
   - reboot requested by exadmin at Sat Dec  4 05:00:00 2021
 ```
+
+### check (pre-flight verification)
+
+Unified pre-flight checks across NETCONF reachability and firmware hashes. Output is an aligned table; exit code is non-zero if any host fails. Default (no flag) runs `--connect` only.
+
+```
+% junos-ops check --all rt1.example.jp rt2.example.jp
+hostname         connect  local       remote      model     file
+---------------  -------  ----------  ----------  --------  -----------------------------------
+rt1.example.jp   ok       ok(cached)  ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+rt2.example.jp   ok       ok          missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+
+  rt2.example.jp: remote: - remote package: jinstall-ppc-18.4R3-S10-signed.tgz is not found.
+```
+
+`--local` works offline (no NETCONF) — useful for verifying a staging server holds every firmware file before you start a large rollout. Provide the model via `--model MX5-T` or add `model = MX5-T` to each host section in `config.ini`. `--remote` doubles as a "did the SCP copy fully land" check between `copy` and `install`.
 
 ### rsi (parallel RSI/SCF collection)
 

--- a/README.md
+++ b/README.md
@@ -380,19 +380,39 @@ rt1.example.jp: software validate package-result: 0
 
 ### check (pre-flight verification)
 
-Unified pre-flight checks across NETCONF reachability and firmware hashes. Output is an aligned table; exit code is non-zero if any host fails. Default (no flag) runs `--connect` only.
+Unified pre-flight checks across NETCONF reachability and firmware hashes. Exit code is non-zero if any check fails. Default (no flag) runs `--connect` only.
+
+`--local` is **inventory-mode** and ignores hostnames — it iterates every `<model>.file` / `<model>.hash` pair in `config.ini` and verifies the files on the staging server. No NETCONF required:
 
 ```
-% junos-ops check --all rt1.example.jp rt2.example.jp
-hostname         connect  local       remote      model     file
----------------  -------  ----------  ----------  --------  -----------------------------------
-rt1.example.jp   ok       ok(cached)  ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
-rt2.example.jp   ok       ok          missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+% junos-ops check --local
+model            file                                                        status      local_file
+---------------  ----------------------------------------------------------  ----------  ----------------------------------------------------------------------
+ex2300-24t       junos-arm-32-23.4R2-S7.4.tgz                                ok          /opt/firmware/junos-arm-32-23.4R2-S7.4.tgz
+ex3400-24t       junos-arm-32-23.4R2-S7.4.tgz                                ok(cached)  /opt/firmware/junos-arm-32-23.4R2-S7.4.tgz
+ex4300-32f       jinstall-ex-4300-21.4R3-S12.2-signed.tgz                    ok          /opt/firmware/jinstall-ex-4300-21.4R3-S12.2-signed.tgz
+mx5-t            jinstall-ppc-21.2R3-S8.5-signed.tgz                         missing     /opt/firmware/jinstall-ppc-21.2R3-S8.5-signed.tgz
+
+  mx5-t: - local package: /opt/firmware/jinstall-ppc-21.2R3-S8.5-signed.tgz is not found.
+```
+
+Use `--model M` to restrict the inventory to a single model.
+
+`--connect` / `--remote` (and `--all`) are **per-host** and use the specified hostnames (or every host in `config.ini`, optionally filtered by `--tags`). `--remote` doubles as a "did the SCP copy fully land" check between `copy` and `install`:
+
+```
+% junos-ops check --connect --remote rt1.example.jp rt2.example.jp
+hostname         connect  remote      model     file
+---------------  -------  ----------  --------  -----------------------------------
+rt1.example.jp   ok       ok          MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
+rt2.example.jp   ok       missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.tgz
 
   rt2.example.jp: remote: - remote package: jinstall-ppc-18.4R3-S10-signed.tgz is not found.
 ```
 
-`--local` works offline (no NETCONF) — useful for verifying a staging server holds every firmware file before you start a large rollout. Provide the model via `--model MX5-T` or add `model = MX5-T` to each host section in `config.ini`. `--remote` doubles as a "did the SCP copy fully land" check between `copy` and `install`.
+When `--connect` / `--remote` need to resolve a model and it was not supplied via `--model`, they fall back to `dev.facts["model"]` from the live device, or to an optional `model = MX5-T` key added to the host section in `config.ini`.
+
+`--all` runs both: the inventory table is printed first, then the per-host table.
 
 ### rsi (parallel RSI/SCF collection)
 

--- a/junos_ops/__init__.py
+++ b/junos_ops/__init__.py
@@ -12,9 +12,10 @@ Subcommands::
     junos-ops rsi [hostname ...]       # collect RSI/SCF
     junos-ops show "show bgp summary"  # run CLI command
     junos-ops config -f FILE           # push set commands
+    junos-ops check [--connect|--local|--remote|--all]  # pre-flight checks
 
 See Also:
     https://github.com/shigechika/junos-ops
 """
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -342,7 +342,9 @@ def _check_host(hostname) -> dict:
                 "message": "connected",
                 "error": None,
             }
-            if model is None:
+            # facts 取得は ~10 RPC と重い。--remote でモデル解決が必要な
+            # 場合だけ実行する（--connect 単独ではスキップして高速化）。
+            if model is None and do_remote:
                 try:
                     model = dev.facts.get("model")
                     if model:
@@ -470,7 +472,7 @@ def main():
     )
     parent.add_argument(
         "--workers", type=int, default=None,
-        help="parallel workers (default: 1 for upgrade, 20 for rsi)",
+        help="parallel workers (default: 1 for upgrade, 20 for rsi/check)",
     )
     parent.add_argument(
         "--tags", type=str, default=None,
@@ -764,7 +766,8 @@ def main():
 
     # workers のデフォルト値設定
     if common.args.workers is None:
-        if args.subcommand == "rsi":
+        if args.subcommand in ("rsi", "check"):
+            # I/O バウンドかつ副作用なしなので並列化しても安全
             common.args.workers = 20
         else:
             common.args.workers = 1

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -301,6 +301,104 @@ def cmd_config(hostname) -> int:
             pass
 
 
+def _check_host(hostname) -> dict:
+    """Worker for the ``check`` subcommand.
+
+    Runs the requested subset of pre-flight checks (connect / local /
+    remote) against a single host and returns a result dict for the
+    display layer to render as a table row. Never raises — unexpected
+    exceptions are captured as ``connect`` errors.
+    """
+    do_connect = common.args.check_connect
+    do_local = common.args.check_local
+    do_remote = common.args.check_remote
+    explicit_model = getattr(common.args, "check_model", None)
+
+    result = {
+        "hostname": hostname,
+        "model": None,
+        "model_source": None,
+        "connect": None,
+        "local": None,
+        "remote": None,
+    }
+
+    # Model resolution order: --model > config.ini [host].model > device facts.
+    model = explicit_model
+    source = "cli" if model else None
+    if model is None:
+        try:
+            cfg_model = common.config.get(hostname, "model")
+            if cfg_model:
+                model = cfg_model
+                source = "config"
+        except Exception:
+            pass
+
+    # Connect is required for --remote; always run when --connect is set.
+    dev = None
+    if do_connect or do_remote:
+        conn = common.connect(hostname)
+        if conn["ok"]:
+            dev = conn["dev"]
+            result["connect"] = {
+                "ok": True,
+                "message": "connected",
+                "error": None,
+            }
+            if model is None:
+                try:
+                    model = dev.facts.get("model")
+                    if model:
+                        source = "device"
+                except Exception as e:
+                    logger.debug(f"{hostname}: facts access failed: {e}")
+        else:
+            result["connect"] = {
+                "ok": False,
+                "message": conn.get("error_message") or "connect failed",
+                "error": conn.get("error"),
+            }
+
+    result["model"] = model
+    result["model_source"] = source
+
+    try:
+        if do_local:
+            if model:
+                result["local"] = upgrade.check_local_package_by_model(
+                    hostname, model
+                )
+            else:
+                result["local"] = {
+                    "status": "unchecked",
+                    "message": "model unknown (pass --model or add `model =` to config.ini)",
+                    "file": None,
+                    "cached": False,
+                }
+        if do_remote:
+            if dev is not None and model:
+                result["remote"] = upgrade.check_remote_package_by_model(
+                    hostname, dev, model
+                )
+            else:
+                reason = "not connected" if dev is None else "model unknown"
+                result["remote"] = {
+                    "status": "unchecked",
+                    "message": reason,
+                    "file": None,
+                    "cached": False,
+                }
+    finally:
+        if dev is not None:
+            try:
+                dev.close()
+            except (ConnectClosedError, Exception):
+                pass
+
+    return result
+
+
 def cmd_ls(hostname) -> int:
     """List remote files."""
     dev = _open_connection(hostname)
@@ -460,6 +558,34 @@ def main():
     )
     p_config.add_argument("specialhosts", metavar="hostname", nargs="*")
 
+    # check
+    p_check = subparsers.add_parser(
+        "check",
+        parents=[parent],
+        help="pre-flight checks (NETCONF reachability, local/remote firmware hash)",
+    )
+    p_check.add_argument(
+        "--connect", dest="check_connect", action="store_true",
+        help="verify NETCONF reachability (default when no flag is given)",
+    )
+    p_check.add_argument(
+        "--local", dest="check_local", action="store_true",
+        help="verify local firmware checksum (no NETCONF required)",
+    )
+    p_check.add_argument(
+        "--remote", dest="check_remote", action="store_true",
+        help="verify remote firmware checksum on the device (requires NETCONF)",
+    )
+    p_check.add_argument(
+        "--all", dest="check_all", action="store_true",
+        help="shorthand for --connect --local --remote",
+    )
+    p_check.add_argument(
+        "--model", dest="check_model", default=None,
+        help="override model lookup (otherwise from config.ini 'model' or device facts)",
+    )
+    p_check.add_argument("specialhosts", metavar="hostname", nargs="*")
+
     # rsi
     p_rsi = subparsers.add_parser(
         "rsi", parents=[parent], help="collect RSI/SCF",
@@ -558,6 +684,26 @@ def main():
         args.rpc_timeout = None
     if not hasattr(args, "no_confirm"):
         args.no_confirm = False
+    if not hasattr(args, "check_connect"):
+        args.check_connect = False
+    if not hasattr(args, "check_local"):
+        args.check_local = False
+    if not hasattr(args, "check_remote"):
+        args.check_remote = False
+    if not hasattr(args, "check_all"):
+        args.check_all = False
+    if not hasattr(args, "check_model"):
+        args.check_model = None
+
+    # check サブコマンドのフラグ解決
+    if args.subcommand == "check":
+        if args.check_all:
+            args.check_connect = True
+            args.check_local = True
+            args.check_remote = True
+        # フラグ未指定なら --connect をデフォルト
+        if not (args.check_connect or args.check_local or args.check_remote):
+            args.check_connect = True
 
     # show サブコマンド: show_args を show_command + specialhosts に分離
     if args.subcommand == "show":
@@ -592,6 +738,33 @@ def main():
             common.args.workers = 20
         else:
             common.args.workers = 1
+
+    # check サブコマンドは table 出力＋exit code 集計を専用処理
+    if args.subcommand == "check":
+        results = common.run_parallel(
+            _check_host, targets, max_workers=common.args.workers
+        )
+        rows = [results[t] for t in targets if t in results]
+        display.print_check_table(
+            rows,
+            show_connect=common.args.check_connect,
+            show_local=common.args.check_local,
+            show_remote=common.args.check_remote,
+        )
+        rc = 0
+        for row in rows:
+            if not isinstance(row, dict):
+                rc = 1
+                continue
+            conn = row.get("connect")
+            if conn is not None and not conn.get("ok"):
+                rc = 1
+            for key in ("local", "remote"):
+                sub = row.get(key)
+                if sub and sub.get("status") in ("bad", "missing", "error"):
+                    rc = 1
+        logger.debug("end")
+        return rc
 
     # サブコマンドのディスパッチ
     dispatch = {

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -334,7 +334,12 @@ def _check_host(hostname) -> dict:
 
     dev = None
     if do_connect or do_remote:
-        conn = common.connect(hostname)
+        # PyEZ の Device.open() は gather_facts=True がデフォルトで、開いた
+        # 瞬間に chassis inventory 等 ~10 RPC を流す。model がもう確定して
+        # いる、または --remote が指定されていない場合は facts は不要なので
+        # gather_facts=False で開いて handshake のみにする。
+        need_facts = do_remote and model is None
+        conn = common.connect(hostname, gather_facts=need_facts)
         if conn["ok"]:
             dev = conn["dev"]
             result["connect"] = {
@@ -342,9 +347,7 @@ def _check_host(hostname) -> dict:
                 "message": "connected",
                 "error": None,
             }
-            # facts 取得は ~10 RPC と重い。--remote でモデル解決が必要な
-            # 場合だけ実行する（--connect 単独ではスキップして高速化）。
-            if model is None and do_remote:
+            if need_facts:
                 try:
                     model = dev.facts.get("model")
                     if model:

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -44,6 +44,11 @@ else:
         format='%(asctime)s [%(levelname)s] %(message)s',
         handlers=[logging.StreamHandler(sys.stdout)]
     )
+    # ncclient / paramiko / junos-eznc emit every NETCONF and SSH frame
+    # at INFO. Without an explicit logging.ini, our INFO root would drown
+    # the user in protocol traffic, so raise these to WARNING by default.
+    for noisy in ("ncclient", "paramiko", "jnpr.junos"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 from junos_ops import __version__ as version  # noqa: E402
@@ -339,7 +344,11 @@ def _check_host(hostname) -> dict:
         # いる、または --remote が指定されていない場合は facts は不要なので
         # gather_facts=False で開いて handshake のみにする。
         need_facts = do_remote and model is None
-        conn = common.connect(hostname, gather_facts=need_facts)
+        # auto_probe=5: 不通ホストを TCP-level の 5 秒で fail させ、OS
+        # デフォルトの ~60-120 秒 SYN タイムアウトで全体が引きずられないように。
+        conn = common.connect(
+            hostname, gather_facts=need_facts, auto_probe=5
+        )
         if conn["ok"]:
             dev = conn["dev"]
             result["connect"] = {

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -358,7 +358,7 @@ def _run_check_with_progress(targets, max_workers: int) -> dict:
                 conn = row.get("connect") or {}
                 conn_status = "ok" if conn.get("ok") else "fail"
                 model = row.get("model") or "-"
-                tqdm.write(f"  {host}: {conn_status}  {model}", file=sys.stderr)
+                bar.set_postfix_str(f"{host} {conn_status} {model}")
                 bar.update(1)
     return results
 

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -306,6 +306,79 @@ def cmd_config(hostname) -> int:
             pass
 
 
+def _run_check_with_progress(targets, max_workers: int) -> dict:
+    """Run ``_check_host`` over targets with a tqdm progress bar.
+
+    Falls back to plain :func:`common.run_parallel` when tqdm is not
+    installed or stderr is not a TTY (CI / piped output). Each
+    completion writes a one-line summary above the bar via
+    ``tqdm.write`` so users see parallel progress, not just a counter.
+    """
+    use_tqdm = sys.stderr.isatty()
+    if use_tqdm:
+        try:
+            from tqdm import tqdm
+        except ImportError:
+            use_tqdm = False
+
+    if not use_tqdm:
+        return common.run_parallel(
+            _check_host, targets, max_workers=max_workers
+        )
+
+    from concurrent import futures as _futures
+    results: dict = {}
+    with _futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+        future_to_host = {ex.submit(_check_host, t): t for t in targets}
+        with tqdm(
+            total=len(targets),
+            desc="check",
+            unit="host",
+            file=sys.stderr,
+            dynamic_ncols=True,
+        ) as bar:
+            for fut in _futures.as_completed(future_to_host):
+                host = future_to_host[fut]
+                try:
+                    row = fut.result()
+                except Exception as e:
+                    logger.error(f"{host}: {e}")
+                    row = {
+                        "hostname": host,
+                        "model": None,
+                        "model_source": None,
+                        "connect": {
+                            "ok": False,
+                            "message": str(e),
+                            "error": type(e).__name__,
+                        },
+                        "remote": None,
+                    }
+                results[host] = row
+                conn = row.get("connect") or {}
+                conn_status = "ok" if conn.get("ok") else "fail"
+                model = row.get("model") or "-"
+                tqdm.write(f"  {host}: {conn_status}  {model}", file=sys.stderr)
+                bar.update(1)
+    return results
+
+
+def _fetch_model_cheap(dev) -> str | None:
+    """Fetch only the device model via a single ``get-software-information``
+    RPC (~100 ms) instead of paying the full PyEZ facts cost (~10 RPCs).
+
+    Returns the ``product-model`` text, or None if the RPC fails or
+    the field is absent.
+    """
+    try:
+        rpc = dev.rpc.get_software_information()
+        elem = rpc.find(".//product-model")
+        return elem.text if elem is not None else None
+    except Exception as e:
+        logger.debug(f"get-software-information failed: {e}")
+        return None
+
+
 def _check_host(hostname) -> dict:
     """Worker for the ``check`` subcommand (per-host checks).
 
@@ -363,6 +436,12 @@ def _check_host(hostname) -> dict:
                         source = "device"
                 except Exception as e:
                     logger.debug(f"{hostname}: facts access failed: {e}")
+            elif model is None:
+                # gather_facts=False のままで model だけ欲しい: 単発 RPC で取得。
+                cheap = _fetch_model_cheap(dev)
+                if cheap:
+                    model = cheap
+                    source = "device"
         else:
             result["connect"] = {
                 "ok": False,
@@ -801,8 +880,8 @@ def main():
             if common.args.check_local:
                 # 2 つ目のテーブルの前にブランク行
                 print("")
-            results = common.run_parallel(
-                _check_host, targets, max_workers=common.args.workers
+            results = _run_check_with_progress(
+                targets, max_workers=common.args.workers
             )
             rows = [results[t] for t in targets if t in results]
             display.print_check_table(

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -455,9 +455,20 @@ def _check_host(hostname) -> dict:
     try:
         if do_remote:
             if dev is not None and model:
-                result["remote"] = upgrade.check_remote_package_by_model(
-                    hostname, dev, model
-                )
+                try:
+                    result["remote"] = upgrade.check_remote_package_by_model(
+                        hostname, dev, model
+                    )
+                except Exception as e:
+                    # config に <model>.file / .hash が無い等の lookup 失敗を
+                    # 接続失敗扱いにすると誤解を招くので、unchecked で記録。
+                    result["remote"] = {
+                        "status": "unchecked",
+                        "message": f"recipe lookup failed: {e}",
+                        "file": None,
+                        "cached": False,
+                        "error": type(e).__name__,
+                    }
             else:
                 reason = "not connected" if dev is None else "model unknown"
                 result["remote"] = {

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -302,15 +302,13 @@ def cmd_config(hostname) -> int:
 
 
 def _check_host(hostname) -> dict:
-    """Worker for the ``check`` subcommand.
+    """Worker for the ``check`` subcommand (per-host checks).
 
-    Runs the requested subset of pre-flight checks (connect / local /
-    remote) against a single host and returns a result dict for the
-    display layer to render as a table row. Never raises — unexpected
-    exceptions are captured as ``connect`` errors.
+    Handles ``--connect`` and ``--remote`` against a single host.
+    ``--local`` is inventory-based and is processed separately by
+    :func:`_check_local_inventory`; this worker ignores it.
     """
     do_connect = common.args.check_connect
-    do_local = common.args.check_local
     do_remote = common.args.check_remote
     explicit_model = getattr(common.args, "check_model", None)
 
@@ -319,7 +317,6 @@ def _check_host(hostname) -> dict:
         "model": None,
         "model_source": None,
         "connect": None,
-        "local": None,
         "remote": None,
     }
 
@@ -335,7 +332,6 @@ def _check_host(hostname) -> dict:
         except Exception:
             pass
 
-    # Connect is required for --remote; always run when --connect is set.
     dev = None
     if do_connect or do_remote:
         conn = common.connect(hostname)
@@ -364,18 +360,6 @@ def _check_host(hostname) -> dict:
     result["model_source"] = source
 
     try:
-        if do_local:
-            if model:
-                result["local"] = upgrade.check_local_package_by_model(
-                    hostname, model
-                )
-            else:
-                result["local"] = {
-                    "status": "unchecked",
-                    "message": "model unknown (pass --model or add `model =` to config.ini)",
-                    "file": None,
-                    "cached": False,
-                }
         if do_remote:
             if dev is not None and model:
                 result["remote"] = upgrade.check_remote_package_by_model(
@@ -397,6 +381,52 @@ def _check_host(hostname) -> dict:
                 pass
 
     return result
+
+
+def _check_local_inventory() -> list[dict]:
+    """Inventory-mode ``check --local``: iterate model→file map in ``config.ini``.
+
+    Ignores hostnames entirely — the local firmware map is an attribute
+    of the staging server, not the devices. Verifies each model's
+    ``<model>.file`` against its ``<model>.hash``, filtered by
+    ``--model`` if supplied. Uses ``"DEFAULT"`` as the config section
+    so DEFAULT-level ``lpath`` / ``hashalgo`` apply.
+    """
+    filter_model = getattr(common.args, "check_model", None)
+    if filter_model:
+        models = [filter_model]
+    else:
+        models = upgrade.iter_configured_models()
+
+    rows: list[dict] = []
+    for model in models:
+        try:
+            result = upgrade.check_local_package_by_model("DEFAULT", model)
+        except Exception as e:
+            rows.append({
+                "model": model,
+                "file": None,
+                "local_file": None,
+                "status": "error",
+                "cached": False,
+                "actual_hash": None,
+                "expected_hash": None,
+                "message": f"config lookup failed: {e}",
+                "error": type(e).__name__,
+            })
+            continue
+        rows.append({
+            "model": model,
+            "file": result.get("file"),
+            "local_file": result.get("local_file"),
+            "status": result.get("status"),
+            "cached": result.get("cached"),
+            "actual_hash": result.get("actual_hash"),
+            "expected_hash": result.get("expected_hash"),
+            "message": result.get("message"),
+            "error": result.get("error"),
+        })
+    return rows
 
 
 def cmd_ls(hostname) -> int:
@@ -739,30 +769,44 @@ def main():
         else:
             common.args.workers = 1
 
-    # check サブコマンドは table 出力＋exit code 集計を専用処理
+    # check サブコマンドは専用処理（local はインベントリ、connect/remote は per-host）
     if args.subcommand == "check":
-        results = common.run_parallel(
-            _check_host, targets, max_workers=common.args.workers
-        )
-        rows = [results[t] for t in targets if t in results]
-        display.print_check_table(
-            rows,
-            show_connect=common.args.check_connect,
-            show_local=common.args.check_local,
-            show_remote=common.args.check_remote,
-        )
         rc = 0
-        for row in rows:
-            if not isinstance(row, dict):
-                rc = 1
-                continue
-            conn = row.get("connect")
-            if conn is not None and not conn.get("ok"):
-                rc = 1
-            for key in ("local", "remote"):
-                sub = row.get(key)
+
+        # --local: staging server 側のファームウェア棚卸し（ホスト非依存）
+        if common.args.check_local:
+            inventory = _check_local_inventory()
+            display.print_check_local_inventory(inventory)
+            for row in inventory:
+                if row.get("status") in ("bad", "missing", "error"):
+                    rc = 1
+
+        # --connect / --remote: ホスト単位でチェック
+        if common.args.check_connect or common.args.check_remote:
+            if common.args.check_local:
+                # 2 つ目のテーブルの前にブランク行
+                print("")
+            results = common.run_parallel(
+                _check_host, targets, max_workers=common.args.workers
+            )
+            rows = [results[t] for t in targets if t in results]
+            display.print_check_table(
+                rows,
+                show_connect=common.args.check_connect,
+                show_local=False,
+                show_remote=common.args.check_remote,
+            )
+            for row in rows:
+                if not isinstance(row, dict):
+                    rc = 1
+                    continue
+                conn = row.get("connect")
+                if conn is not None and not conn.get("ok"):
+                    rc = 1
+                sub = row.get("remote")
                 if sub and sub.get("status") in ("bad", "missing", "error"):
                     rc = 1
+
         logger.debug("end")
         return rc
 

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -82,7 +82,9 @@ def read_config() -> dict:
     }
 
 
-def connect(hostname: str, *, gather_facts: bool = True) -> dict:
+def connect(
+    hostname: str, *, gather_facts: bool = True, auto_probe: int = 0
+) -> dict:
     """Open a NETCONF connection to a device.
 
     :param hostname: config section name (host identifier).
@@ -92,6 +94,11 @@ def connect(hostname: str, *, gather_facts: bool = True) -> dict:
         for fast reachability-only probes such as ``check --connect``;
         callers that genuinely need ``dev.facts`` (most subcommands)
         should leave the default True.
+    :param auto_probe: when > 0, do a TCP-level reachability probe
+        with this timeout (seconds) before attempting NETCONF/SSH
+        negotiation. Lets unreachable hosts fail fast instead of
+        hanging on the OS-default TCP connect timeout (60–120 s).
+        Default 0 keeps the existing PyEZ behaviour.
     :return: dict with keys:
 
         - ``hostname`` (str): the config section name passed in.

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -82,10 +82,16 @@ def read_config() -> dict:
     }
 
 
-def connect(hostname: str) -> dict:
+def connect(hostname: str, *, gather_facts: bool = True) -> dict:
     """Open a NETCONF connection to a device.
 
     :param hostname: config section name (host identifier).
+    :param gather_facts: when False, ``Device.open()`` skips PyEZ's
+        automatic facts collection (~10 RPCs covering chassis
+        inventory, routing-engine info, hosts.junos, etc.). Use this
+        for fast reachability-only probes such as ``check --connect``;
+        callers that genuinely need ``dev.facts`` (most subcommands)
+        should leave the default True.
     :return: dict with keys:
 
         - ``hostname`` (str): the config section name passed in.
@@ -110,6 +116,7 @@ def connect(hostname: str) -> dict:
         passwd=config.get(hostname, "pw"),
         ssh_private_key_file=os.path.expanduser(config.get(hostname, "sshkey")),
         huge_tree=config.getboolean(hostname, "huge_tree", fallback=False),
+        gather_facts=gather_facts,
     )
     _ERROR_PREFIX = {
         ConnectAuthError: "Authentication credentials fail to login",

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -550,3 +550,51 @@ def print_check_table(
         show_local=show_local,
         show_remote=show_remote,
     ))
+
+
+def format_check_local_inventory(rows: list[dict]) -> str:
+    """Render ``check --local`` inventory results (one row per model).
+
+    ``rows`` come from :func:`cli._check_local_inventory`. Columns:
+    ``model`` / ``file`` / ``status`` / ``local_file``. Failure detail
+    messages (bad / missing / error) are appended below the table.
+    """
+    headers = ["model", "file", "status", "local_file"]
+    body: list[list[str]] = []
+    for r in rows:
+        status = r.get("status", "-")
+        if status == "ok" and r.get("cached"):
+            status = "ok(cached)"
+        body.append([
+            r.get("model") or "-",
+            r.get("file") or "-",
+            status,
+            r.get("local_file") or "-",
+        ])
+
+    widths = [
+        max(len(headers[i]), *(len(b[i]) for b in body)) if body else len(headers[i])
+        for i in range(len(headers))
+    ]
+
+    def _fmt_row(cells: list[str]) -> str:
+        return "  ".join(c.ljust(widths[i]) for i, c in enumerate(cells)).rstrip()
+
+    lines = [_fmt_row(headers), _fmt_row(["-" * w for w in widths])]
+    lines.extend(_fmt_row(r) for r in body)
+
+    detail_lines: list[str] = []
+    for r in rows:
+        if r.get("status") in ("bad", "missing", "error"):
+            msg = (r.get("message") or "").lstrip()
+            detail_lines.append(f"  {r.get('model')}: {msg}")
+    if detail_lines:
+        lines.append("")
+        lines.extend(detail_lines)
+
+    return "\n".join(lines)
+
+
+def print_check_local_inventory(rows: list[dict]) -> None:
+    """Print ``check --local`` inventory table."""
+    _emit(format_check_local_inventory(rows))

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -437,3 +437,116 @@ def print_rsi(result: dict) -> None:
 def print_show(result: dict) -> None:
     """Print ``cmd_show`` result (a list of command/output pairs)."""
     raise NotImplementedError
+
+
+# -------------------------------------------------------------------
+# check
+# -------------------------------------------------------------------
+
+
+def _short_check_status(sub: dict | None) -> str:
+    """Render a local/remote check sub-result as a short column label."""
+    if sub is None:
+        return "-"
+    status = sub.get("status", "-")
+    if status == "ok" and sub.get("cached"):
+        return "ok(cached)"
+    return status
+
+
+def _short_connect_status(sub: dict | None) -> str:
+    """Render a connect sub-result as ``ok`` / ``fail`` / ``-``."""
+    if sub is None:
+        return "-"
+    return "ok" if sub.get("ok") else "fail"
+
+
+def format_check_table(
+    rows: list[dict],
+    *,
+    show_connect: bool = True,
+    show_local: bool = False,
+    show_remote: bool = False,
+) -> str:
+    """Render ``check`` subcommand results as an aligned table.
+
+    Each row is the dict returned by the ``check`` worker with keys
+    ``hostname``, ``model``, ``model_source``, ``connect``, ``local``,
+    ``remote``. Columns are included based on the ``show_*`` flags so
+    a single-aspect run (e.g. ``check --connect``) does not emit empty
+    columns.
+    """
+    headers: list[str] = ["hostname"]
+    if show_connect:
+        headers.append("connect")
+    if show_local:
+        headers.append("local")
+    if show_remote:
+        headers.append("remote")
+    headers.extend(["model", "file"])
+
+    body: list[list[str]] = []
+    for row in rows:
+        line = [row.get("hostname") or "-"]
+        if show_connect:
+            line.append(_short_connect_status(row.get("connect")))
+        if show_local:
+            line.append(_short_check_status(row.get("local")))
+        if show_remote:
+            line.append(_short_check_status(row.get("remote")))
+        line.append(row.get("model") or "-")
+        file_val = None
+        for key in ("local", "remote"):
+            sub = row.get(key)
+            if sub and sub.get("file"):
+                file_val = sub["file"]
+                break
+        line.append(file_val or "-")
+        body.append(line)
+
+    widths = [
+        max(len(headers[i]), *(len(r[i]) for r in body)) if body else len(headers[i])
+        for i in range(len(headers))
+    ]
+
+    def _fmt_row(cells: list[str]) -> str:
+        return "  ".join(c.ljust(widths[i]) for i, c in enumerate(cells)).rstrip()
+
+    lines = [_fmt_row(headers), _fmt_row(["-" * w for w in widths])]
+    lines.extend(_fmt_row(r) for r in body)
+
+    # Surface detailed failure messages below the table.
+    detail_lines: list[str] = []
+    for row in rows:
+        host = row.get("hostname") or "?"
+        conn = row.get("connect")
+        if conn and not conn.get("ok"):
+            msg = conn.get("message") or conn.get("error") or "connect failed"
+            detail_lines.append(f"  {host}: connect: {msg}")
+        for key in ("local", "remote"):
+            sub = row.get(key)
+            if sub and sub.get("status") in ("bad", "missing", "error"):
+                detail_lines.append(
+                    f"  {host}: {key}: {sub.get('message', '').lstrip()}"
+                )
+    if detail_lines:
+        lines.append("")
+        lines.extend(detail_lines)
+
+    return "\n".join(lines)
+
+
+def print_check_table(
+    rows: list[dict],
+    *,
+    show_connect: bool = True,
+    show_local: bool = False,
+    show_remote: bool = False,
+) -> None:
+    """Print ``check`` subcommand results as an aligned table."""
+    _emit(format_check_table(
+        rows,
+        show_connect=show_connect,
+        show_local=show_local,
+        show_remote=show_remote,
+    ))

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -556,10 +556,13 @@ def format_check_local_inventory(rows: list[dict]) -> str:
     """Render ``check --local`` inventory results (one row per model).
 
     ``rows`` come from :func:`cli._check_local_inventory`. Columns:
-    ``model`` / ``file`` / ``status`` / ``local_file``. Failure detail
-    messages (bad / missing / error) are appended below the table.
+    ``model`` / ``file`` / ``status``. When any row resolves its
+    firmware under a non-empty ``lpath`` directory, that prefix is
+    shown once above the table (``lpath: /path``) instead of being
+    duplicated into every row. Failure detail messages (bad / missing
+    / error) are appended below.
     """
-    headers = ["model", "file", "status", "local_file"]
+    headers = ["model", "file", "status"]
     body: list[list[str]] = []
     for r in rows:
         status = r.get("status", "-")
@@ -569,7 +572,6 @@ def format_check_local_inventory(rows: list[dict]) -> str:
             r.get("model") or "-",
             r.get("file") or "-",
             status,
-            r.get("local_file") or "-",
         ])
 
     widths = [
@@ -580,7 +582,22 @@ def format_check_local_inventory(rows: list[dict]) -> str:
     def _fmt_row(cells: list[str]) -> str:
         return "  ".join(c.ljust(widths[i]) for i, c in enumerate(cells)).rstrip()
 
-    lines = [_fmt_row(headers), _fmt_row(["-" * w for w in widths])]
+    lines: list[str] = []
+    # Surface a single lpath header instead of repeating it per row.
+    lpaths = {
+        r.get("local_file", "").rsplit("/", 1)[0]
+        for r in rows
+        if r.get("local_file") and "/" in r.get("local_file", "")
+        and r.get("local_file") != r.get("file")
+    }
+    if len(lpaths) == 1:
+        lines.append(f"lpath: {lpaths.pop()}")
+    elif len(lpaths) > 1:
+        # Rare: host-section overrides mix lpaths — fall back to per-row.
+        lines.extend(f"lpath[{r.get('model')}]: {r.get('local_file')}" for r in rows)
+
+    lines.append(_fmt_row(headers))
+    lines.append(_fmt_row(["-" * w for w in widths]))
     lines.extend(_fmt_row(r) for r in body)
 
     detail_lines: list[str] = []

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -515,7 +515,10 @@ def format_check_table(
     lines = [_fmt_row(headers), _fmt_row(["-" * w for w in widths])]
     lines.extend(_fmt_row(r) for r in body)
 
-    # Surface detailed failure messages below the table.
+    # Surface detailed failure messages below the table. ``missing`` is
+    # already obvious from the status + file columns above, so only
+    # ``bad`` (checksum mismatch) and ``error`` (recipe lookup, RPC,
+    # etc.) earn a detail line; connect failures always do.
     detail_lines: list[str] = []
     for row in rows:
         host = row.get("hostname") or "?"
@@ -525,7 +528,7 @@ def format_check_table(
             detail_lines.append(f"  {host}: connect: {msg}")
         for key in ("local", "remote"):
             sub = row.get(key)
-            if sub and sub.get("status") in ("bad", "missing", "error"):
+            if sub and sub.get("status") in ("bad", "error"):
                 detail_lines.append(
                     f"  {host}: {key}: {sub.get('message', '').lstrip()}"
                 )
@@ -600,9 +603,12 @@ def format_check_local_inventory(rows: list[dict]) -> str:
     lines.append(_fmt_row(["-" * w for w in widths]))
     lines.extend(_fmt_row(r) for r in body)
 
+    # ``missing`` rows are already self-explanatory from the file +
+    # status columns; only ``bad`` / ``error`` carry information not
+    # already in the table, so reserve detail lines for those.
     detail_lines: list[str] = []
     for r in rows:
-        if r.get("status") in ("bad", "missing", "error"):
+        if r.get("status") in ("bad", "error"):
             msg = (r.get("message") or "").lstrip()
             detail_lines.append(f"  {r.get('model')}: {msg}")
     if detail_lines:

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -669,6 +669,20 @@ def set_hashcache(hostname, file, value):
         common.config.set(hostname, file + "hashcache", value)
 
 
+def iter_configured_models() -> list[str]:
+    """Enumerate unique model names with ``<model>.file`` in the DEFAULT section.
+
+    Used by ``check --local`` inventory mode to walk the firmware map
+    without needing a host list. Returns lowercase names (configparser
+    lowercases keys); display rendering preserves this.
+    """
+    models: set[str] = set()
+    for key in common.config.defaults():
+        if key.endswith(".file"):
+            models.add(key[: -len(".file")])
+    return sorted(models)
+
+
 def _compute_local_checksum(path: str, algo: str) -> str:
     """Compute a file checksum using hashlib (no PyEZ/device required).
 

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -13,6 +13,7 @@ from lxml import etree
 from ncclient.operations.errors import TimeoutExpiredError
 import argparse
 import datetime
+import hashlib
 import os
 import re
 from logging import getLogger
@@ -668,39 +669,36 @@ def set_hashcache(hostname, file, value):
         common.config.set(hostname, file + "hashcache", value)
 
 
-def check_local_package(hostname, dev) -> dict:
-    """Check the local package file's checksum against the expected value.
+def _compute_local_checksum(path: str, algo: str) -> str:
+    """Compute a file checksum using hashlib (no PyEZ/device required).
 
-    :return: dict with keys:
+    :param path: absolute or expanded local path.
+    :param algo: algorithm name accepted by :func:`hashlib.new`
+        (e.g. ``"md5"``, ``"sha1"``, ``"sha256"``, ``"sha512"``).
+    :raises FileNotFoundError: the file does not exist.
+    :raises ValueError: algorithm name not recognized by hashlib.
+    """
+    h = hashlib.new(algo)
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
-        - ``hostname`` (str)
-        - ``file`` (str): package filename from config (without path).
-        - ``local_file`` (str): full local path resolved via ``lpath``.
-        - ``algo`` (str): checksum algorithm name.
-        - ``expected_hash`` (str): expected checksum from config.
-        - ``actual_hash`` (str | None): checksum actually computed (or
-          cached). None when the file could not be hashed.
-        - ``status`` (str): one of
 
-          * ``"ok"``      — file present, checksum matches.
-          * ``"bad"``     — file present, checksum does not match.
-          * ``"missing"`` — file not found on the local filesystem.
-          * ``"error"``   — ``sw.local_checksum`` raised an unexpected
-            exception (see ``error``).
-          * ``"unchecked"`` — the model has no configured package
-            mapping (empty file name or hash); no check attempted.
+def check_local_package_by_model(hostname: str, model: str) -> dict:
+    """Device-less local package checksum verification.
 
-        - ``cached`` (bool): True iff the result was served from the
-          in-process hash cache and no disk I/O was performed.
-        - ``message`` (str): a human-readable summary line suitable
-          for the display layer (legacy single-line format).
-        - ``error`` (str | None): exception class name when ``status``
-          is ``"error"``.
+    Resolves the expected filename / hash from ``config.ini`` using the
+    explicit ``model`` argument, then verifies the file on the staging
+    server's filesystem via :mod:`hashlib`. No NETCONF / PyEZ device
+    connection is required, so this is suitable for bulk pre-flight
+    checks on many hosts from a staging server.
+
+    :return: same dict schema as :func:`check_local_package`.
 
     Does not print.
     """
-    logger.debug("check_local_package: start")
-    model = dev.facts["model"]
+    logger.debug("check_local_package_by_model: start")
     file = get_model_file(hostname, model)
     local_file = get_local_path(hostname, file)
     pkg_hash = get_model_hash(hostname, model)
@@ -730,9 +728,8 @@ def check_local_package(hostname, dev) -> dict:
         )
         return result
 
-    sw = SW(dev)
     try:
-        val = sw.local_checksum(local_file, algorithm=algo)
+        val = _compute_local_checksum(local_file, algo)
         result["actual_hash"] = val
         if val == pkg_hash:
             set_hashcache("localhost", file, val)
@@ -757,26 +754,61 @@ def check_local_package(hostname, dev) -> dict:
             f"  - local package: {local_file} checksum error: {e}"
         )
         logger.error(e)
-    finally:
-        del sw
     return result
 
 
-def check_remote_package(hostname, dev) -> dict:
-    """Check the remote package file's checksum against the expected value.
+def check_local_package(hostname, dev) -> dict:
+    """Check the local package file's checksum against the expected value.
 
-    Same schema as :func:`check_local_package`, but targets the device's
-    ``rpath`` directory via ``sw.remote_checksum``.
+    Thin wrapper that resolves the device model from ``dev.facts`` then
+    delegates to :func:`check_local_package_by_model`. Retained for
+    backward compatibility with callers that have a live device.
 
-    :return: dict with the same keys as :func:`check_local_package`,
-        minus ``local_file`` and plus ``remote_path``. ``status``
-        values are identical (``"ok"`` / ``"bad"`` / ``"missing"`` /
-        ``"error"`` / ``"unchecked"``).
+    :return: dict with keys:
+
+        - ``hostname`` (str)
+        - ``file`` (str): package filename from config (without path).
+        - ``local_file`` (str): full local path resolved via ``lpath``.
+        - ``algo`` (str): checksum algorithm name.
+        - ``expected_hash`` (str): expected checksum from config.
+        - ``actual_hash`` (str | None): checksum actually computed (or
+          cached). None when the file could not be hashed.
+        - ``status`` (str): one of
+
+          * ``"ok"``      — file present, checksum matches.
+          * ``"bad"``     — file present, checksum does not match.
+          * ``"missing"`` — file not found on the local filesystem.
+          * ``"error"``   — hashing raised an unexpected exception
+            (see ``error``).
+          * ``"unchecked"`` — the model has no configured package
+            mapping (empty file name or hash); no check attempted.
+
+        - ``cached`` (bool): True iff the result was served from the
+          in-process hash cache and no disk I/O was performed.
+        - ``message`` (str): a human-readable summary line suitable
+          for the display layer (legacy single-line format).
+        - ``error`` (str | None): exception class name when ``status``
+          is ``"error"``.
 
     Does not print.
     """
-    logger.debug("check_remote_package: start")
-    model = dev.facts["model"]
+    return check_local_package_by_model(hostname, dev.facts["model"])
+
+
+def check_remote_package_by_model(hostname: str, dev, model: str) -> dict:
+    """Verify the remote package checksum using an explicit model.
+
+    Device connection is still required (remote checksum is computed
+    by the device itself via NETCONF), but the model is supplied by
+    the caller instead of being derived from ``dev.facts["model"]``.
+    Useful when the caller has already resolved the model from
+    ``config.ini`` or a CLI flag.
+
+    :return: same dict schema as :func:`check_remote_package`.
+
+    Does not print.
+    """
+    logger.debug("check_remote_package_by_model: start")
     file = get_model_file(hostname, model)
     pkg_hash = get_model_hash(hostname, model)
     algo = common.config.get(hostname, "hashalgo")
@@ -837,6 +869,22 @@ def check_remote_package(hostname, dev) -> dict:
     finally:
         del sw
     return result
+
+
+def check_remote_package(hostname, dev) -> dict:
+    """Check the remote package file's checksum against the expected value.
+
+    Thin wrapper that resolves the device model from ``dev.facts`` then
+    delegates to :func:`check_remote_package_by_model`.
+
+    :return: dict with the same keys as :func:`check_local_package`,
+        minus ``local_file`` and plus ``remote_path``. ``status`` values
+        are identical (``"ok"`` / ``"bad"`` / ``"missing"`` / ``"error"``
+        / ``"unchecked"``).
+
+    Does not print.
+    """
+    return check_remote_package_by_model(hostname, dev, dev.facts["model"])
 
 
 def list_remote_path(hostname, dev) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Changelog = "https://github.com/shigechika/junos-ops/blob/main/CHANGELOG.md"
 test = ["pytest", "pytest-cov"]
 completion = ["argcomplete"]
 template = ["Jinja2>=3.1"]
+progress = ["tqdm>=4"]
 
 [project.scripts]
 junos-ops = "junos_ops.cli:main"

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -117,13 +117,35 @@ def _make_check_args(**overrides):
     return base
 
 
+class TestFetchModelCheap:
+    def test_parses_product_model(self):
+        from lxml import etree
+        dev = MagicMock()
+        dev.rpc.get_software_information.return_value = etree.fromstring(
+            "<software-information><product-model>MX5-T</product-model>"
+            "<host-name>rt1</host-name></software-information>"
+        )
+        assert cli._fetch_model_cheap(dev) == "MX5-T"
+
+    def test_returns_none_on_rpc_error(self):
+        dev = MagicMock()
+        dev.rpc.get_software_information.side_effect = RuntimeError("boom")
+        assert cli._fetch_model_cheap(dev) is None
+
+    def test_returns_none_when_field_missing(self):
+        from lxml import etree
+        dev = MagicMock()
+        dev.rpc.get_software_information.return_value = etree.fromstring(
+            "<software-information><host-name>rt1</host-name></software-information>"
+        )
+        assert cli._fetch_model_cheap(dev) is None
+
+
 class TestCheckHostWorker:
-    def test_connect_only_ok_skips_facts(self, mock_config):
-        """--connect alone does NOT access dev.facts (facts collection ~10 RPCs)."""
+    def test_connect_only_uses_cheap_model_rpc(self, mock_config):
+        """--connect uses the single get-software-information RPC, not full facts."""
         common.args = _make_check_args(check_connect=True)
         mock_dev = MagicMock()
-        # If facts were accessed, returning a dict via MagicMock would still
-        # succeed; the assertion is on the attribute access count instead.
         with patch.object(
             common, "connect",
             return_value={
@@ -134,13 +156,16 @@ class TestCheckHostWorker:
                 "error": None,
                 "error_message": None,
             },
-        ):
+        ), patch.object(
+            cli, "_fetch_model_cheap", return_value="MX5-T"
+        ) as mock_cheap:
             result = cli._check_host("test-host")
         assert result["connect"]["ok"] is True
         assert result["remote"] is None
-        # --connect only: model is NOT fetched from facts.
-        assert result["model"] is None
-        assert result["model_source"] is None
+        assert result["model"] == "MX5-T"
+        assert result["model_source"] == "device"
+        mock_cheap.assert_called_once_with(mock_dev)
+        # Full facts collection must NOT be triggered.
         mock_dev.facts.get.assert_not_called()
         mock_dev.close.assert_called_once()
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -118,10 +118,12 @@ def _make_check_args(**overrides):
 
 
 class TestCheckHostWorker:
-    def test_connect_only_ok(self, mock_config):
+    def test_connect_only_ok_skips_facts(self, mock_config):
+        """--connect alone does NOT access dev.facts (facts collection ~10 RPCs)."""
         common.args = _make_check_args(check_connect=True)
         mock_dev = MagicMock()
-        mock_dev.facts = {"model": "EX2300-24T"}
+        # If facts were accessed, returning a dict via MagicMock would still
+        # succeed; the assertion is on the attribute access count instead.
         with patch.object(
             common, "connect",
             return_value={
@@ -136,9 +138,35 @@ class TestCheckHostWorker:
             result = cli._check_host("test-host")
         assert result["connect"]["ok"] is True
         assert result["remote"] is None
+        # --connect only: model is NOT fetched from facts.
+        assert result["model"] is None
+        assert result["model_source"] is None
+        mock_dev.facts.get.assert_not_called()
+        mock_dev.close.assert_called_once()
+
+    def test_connect_plus_remote_fetches_model_from_facts(self, mock_config):
+        """--remote needs the model → facts access is allowed."""
+        common.args = _make_check_args(check_connect=True, check_remote=True)
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(
+            common, "connect",
+            return_value={
+                "hostname": "test-host",
+                "host": "192.0.2.1",
+                "ok": True,
+                "dev": mock_dev,
+                "error": None,
+                "error_message": None,
+            },
+        ), patch.object(
+            junos_upgrade_mod,
+            "check_remote_package_by_model",
+            return_value={"status": "ok", "file": "pkg", "cached": False},
+        ):
+            result = cli._check_host("test-host")
         assert result["model"] == "EX2300-24T"
         assert result["model_source"] == "device"
-        mock_dev.close.assert_called_once()
 
     def test_connect_fail(self, mock_config):
         common.args = _make_check_args(check_connect=True)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -227,7 +227,8 @@ class TestCheckLocalInventory:
         mock_chk.assert_called_once_with("DEFAULT", "EX2300-24T")
         assert len(rows) == 1
 
-    def test_format_inventory(self):
+    def test_format_inventory_with_lpath_header(self):
+        """Shared lpath is shown once above the table, not repeated per row."""
         rows = [
             {
                 "model": "ex2300-24t",
@@ -246,12 +247,29 @@ class TestCheckLocalInventory:
             },
         ]
         out = display.format_check_local_inventory(rows)
-        assert "model" in out.splitlines()[0]
+        lines = out.splitlines()
+        assert lines[0] == "lpath: /opt/fw"
+        assert lines[1].startswith("model")
+        # local_file column is dropped.
+        assert "local_file" not in out
         assert "ok(cached)" in out
         assert "missing" in out
-        # Detail line for missing entry surfaces the filename.
-        assert "mx5-t:" in out
-        assert "is not found" in out
+        assert "mx5-t:" in out  # detail line
+
+    def test_format_inventory_without_lpath(self):
+        """When lpath is unset (local_file == file), no lpath header is emitted."""
+        rows = [
+            {
+                "model": "ex2300-24t",
+                "file": "junos-arm.tgz",
+                "local_file": "junos-arm.tgz",
+                "status": "ok",
+                "cached": False,
+            },
+        ]
+        out = display.format_check_local_inventory(rows)
+        assert not out.startswith("lpath:")
+        assert out.splitlines()[0].startswith("model")
 
 
 class TestFormatCheckTable:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -306,8 +306,9 @@ class TestCheckLocalInventory:
         # local_file column is dropped.
         assert "local_file" not in out
         assert "ok(cached)" in out
-        assert "missing" in out
-        assert "mx5-t:" in out  # detail line
+        assert "missing" in out  # status column shows it
+        # 'missing' has no detail line (status + file column already convey it).
+        assert "mx5-t:" not in out
 
     def test_format_inventory_without_lpath(self):
         """When lpath is unset (local_file == file), no lpath header is emitted."""
@@ -397,9 +398,10 @@ class TestFormatCheckTable:
             rows, show_connect=True, show_local=True, show_remote=True
         )
         assert "ok(cached)" in out
-        assert "missing" in out
+        assert "missing" in out  # status column shows it
         assert "jinstall-ppc.tgz" in out
-        assert "rt2: remote:" in out  # detail line
+        # 'missing' alone no longer triggers a detail line (redundant).
+        assert "rt2: remote:" not in out
 
     def test_empty_rows_renders_header(self):
         out = display.format_check_table(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,307 @@
+"""Tests for the ``check`` subcommand (pre-flight verification).
+
+Covers three surfaces:
+
+1. ``upgrade.check_local_package_by_model`` — the device-less local
+   checksum helper that ``check --local`` uses.
+2. ``upgrade.check_remote_package_by_model`` — the by-model variant
+   that ``check --remote`` uses when the model comes from
+   ``config.ini`` or ``--model``.
+3. ``cli._check_host`` — the worker that dispatches the requested
+   subset of checks and returns a result dict for the table renderer.
+4. ``display.format_check_table`` — column selection, status labels,
+   and failure-detail rendering.
+"""
+
+import argparse
+import hashlib
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from junos_ops import cli
+from junos_ops import common
+from junos_ops import display
+from junos_ops import upgrade as junos_upgrade_mod
+
+
+# -------------------------------------------------------------------
+# check_local_package_by_model
+# -------------------------------------------------------------------
+
+
+class TestCheckLocalPackageByModel:
+    def test_ok_with_real_file(self, mock_args, mock_config, tmp_path, capsys):
+        """Creates a real file, computes md5, verifies status=ok."""
+        pkg = tmp_path / "junos-arm-32-22.4R3-S6.5.tgz"
+        pkg.write_bytes(b"firmware-bytes")
+        expected = hashlib.md5(b"firmware-bytes").hexdigest()
+        common.config.set("DEFAULT", "lpath", str(tmp_path))
+        common.config.set("DEFAULT", "ex2300-24t.hash", expected)
+
+        result = junos_upgrade_mod.check_local_package_by_model(
+            "test-host", "EX2300-24T"
+        )
+        assert result["status"] == "ok"
+        assert result["cached"] is False
+        assert result["actual_hash"] == expected
+        assert capsys.readouterr().out == ""
+
+    def test_missing_file(self, mock_args, mock_config, tmp_path, capsys):
+        common.config.set("DEFAULT", "lpath", str(tmp_path))
+        result = junos_upgrade_mod.check_local_package_by_model(
+            "test-host", "EX2300-24T"
+        )
+        assert result["status"] == "missing"
+        assert result["actual_hash"] is None
+        assert capsys.readouterr().out == ""
+
+    def test_bad_checksum(self, mock_args, mock_config, tmp_path, capsys):
+        pkg = tmp_path / "junos-arm-32-22.4R3-S6.5.tgz"
+        pkg.write_bytes(b"other-bytes")
+        common.config.set("DEFAULT", "lpath", str(tmp_path))
+        # Expected hash in mock_config is "abc123def456" — won't match.
+        result = junos_upgrade_mod.check_local_package_by_model(
+            "test-host", "EX2300-24T"
+        )
+        assert result["status"] == "bad"
+        assert result["actual_hash"] != "abc123def456"
+        assert capsys.readouterr().out == ""
+
+
+# -------------------------------------------------------------------
+# check_remote_package_by_model
+# -------------------------------------------------------------------
+
+
+class TestCheckRemotePackageByModel:
+    def test_delegation(self, mock_args, mock_config, capsys):
+        dev = MagicMock()
+        # facts NOT accessed when model is supplied explicitly.
+        dev.facts = {"model": "should-not-be-read"}
+        mock_sw = MagicMock()
+        mock_sw.remote_checksum.return_value = "abc123def456"
+        with patch.object(junos_upgrade_mod, "SW", return_value=mock_sw):
+            result = junos_upgrade_mod.check_remote_package_by_model(
+                "test-host", dev, "EX2300-24T"
+            )
+        assert result["status"] == "ok"
+        mock_sw.remote_checksum.assert_called_once_with(
+            "/var/tmp/junos-arm-32-22.4R3-S6.5.tgz", algorithm="md5"
+        )
+        assert capsys.readouterr().out == ""
+
+
+# -------------------------------------------------------------------
+# cli._check_host
+# -------------------------------------------------------------------
+
+
+def _make_check_args(**overrides):
+    base = argparse.Namespace(
+        debug=False,
+        dry_run=False,
+        force=False,
+        config="config.ini",
+        tags=None,
+        workers=1,
+        specialhosts=[],
+        check_connect=False,
+        check_local=False,
+        check_remote=False,
+        check_all=False,
+        check_model=None,
+    )
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+class TestCheckHostWorker:
+    def test_connect_only_ok(self, mock_config):
+        common.args = _make_check_args(check_connect=True)
+        mock_dev = MagicMock()
+        mock_dev.facts = {"model": "EX2300-24T"}
+        with patch.object(
+            common, "connect",
+            return_value={
+                "hostname": "test-host",
+                "host": "192.0.2.1",
+                "ok": True,
+                "dev": mock_dev,
+                "error": None,
+                "error_message": None,
+            },
+        ):
+            result = cli._check_host("test-host")
+        assert result["connect"]["ok"] is True
+        assert result["local"] is None
+        assert result["remote"] is None
+        assert result["model"] == "EX2300-24T"
+        assert result["model_source"] == "device"
+        mock_dev.close.assert_called_once()
+
+    def test_connect_fail(self, mock_config):
+        common.args = _make_check_args(check_connect=True)
+        with patch.object(
+            common, "connect",
+            return_value={
+                "hostname": "test-host",
+                "host": "192.0.2.1",
+                "ok": False,
+                "dev": None,
+                "error": "ConnectTimeoutError",
+                "error_message": "Connection timeout",
+            },
+        ):
+            result = cli._check_host("test-host")
+        assert result["connect"]["ok"] is False
+        assert result["connect"]["error"] == "ConnectTimeoutError"
+        assert result["model"] is None
+
+    def test_local_only_uses_explicit_model(self, mock_config):
+        """--local --model MODEL skips NETCONF entirely."""
+        common.args = _make_check_args(
+            check_local=True, check_model="EX2300-24T"
+        )
+        with patch.object(common, "connect") as mock_conn, patch.object(
+            junos_upgrade_mod,
+            "check_local_package_by_model",
+            return_value={"status": "ok", "file": "pkg", "cached": False},
+        ) as mock_chk:
+            result = cli._check_host("test-host")
+        mock_conn.assert_not_called()
+        mock_chk.assert_called_once_with("test-host", "EX2300-24T")
+        assert result["local"]["status"] == "ok"
+        assert result["model_source"] == "cli"
+
+    def test_local_only_from_config_model(self, mock_config):
+        """--local reads model from config.ini [host].model when --model absent."""
+        common.config.set("test-host", "model", "EX2300-24T")
+        common.args = _make_check_args(check_local=True)
+        with patch.object(common, "connect") as mock_conn, patch.object(
+            junos_upgrade_mod,
+            "check_local_package_by_model",
+            return_value={"status": "ok", "file": "pkg", "cached": False},
+        ):
+            result = cli._check_host("test-host")
+        mock_conn.assert_not_called()
+        assert result["model_source"] == "config"
+        assert result["model"] == "EX2300-24T"
+
+    def test_local_unchecked_when_model_unknown(self, mock_config):
+        common.args = _make_check_args(check_local=True)
+        with patch.object(common, "connect") as mock_conn:
+            result = cli._check_host("test-host")
+        mock_conn.assert_not_called()
+        assert result["local"]["status"] == "unchecked"
+        assert "model unknown" in result["local"]["message"]
+
+    def test_remote_unchecked_when_connect_fails(self, mock_config):
+        common.args = _make_check_args(
+            check_connect=True, check_remote=True, check_model="EX2300-24T"
+        )
+        with patch.object(
+            common, "connect",
+            return_value={
+                "hostname": "test-host",
+                "host": "192.0.2.1",
+                "ok": False,
+                "dev": None,
+                "error": "ConnectRefusedError",
+                "error_message": "refused",
+            },
+        ):
+            result = cli._check_host("test-host")
+        assert result["connect"]["ok"] is False
+        assert result["remote"]["status"] == "unchecked"
+        assert result["remote"]["message"] == "not connected"
+
+
+# -------------------------------------------------------------------
+# display.format_check_table
+# -------------------------------------------------------------------
+
+
+class TestFormatCheckTable:
+    def test_connect_only_columns(self):
+        rows = [
+            {
+                "hostname": "rt1",
+                "model": "MX5-T",
+                "connect": {"ok": True, "message": "connected"},
+                "local": None,
+                "remote": None,
+            },
+            {
+                "hostname": "rt2",
+                "model": None,
+                "connect": {"ok": False, "message": "Connection timeout"},
+                "local": None,
+                "remote": None,
+            },
+        ]
+        out = display.format_check_table(
+            rows, show_connect=True, show_local=False, show_remote=False
+        )
+        lines = out.splitlines()
+        # Header + separator + 2 rows + blank + 1 detail line = 6
+        assert lines[0].startswith("hostname")
+        assert "connect" in lines[0]
+        assert "local" not in lines[0]
+        assert "remote" not in lines[0]
+        assert "rt1" in out and "ok" in out
+        assert "rt2" in out and "fail" in out
+        assert "Connection timeout" in out  # detail block
+
+    def test_all_columns_with_cached_and_failures(self):
+        rows = [
+            {
+                "hostname": "rt1",
+                "model": "MX5-T",
+                "connect": {"ok": True, "message": "connected"},
+                "local": {
+                    "status": "ok",
+                    "cached": True,
+                    "file": "jinstall-ppc.tgz",
+                    "message": "",
+                },
+                "remote": {
+                    "status": "ok",
+                    "cached": False,
+                    "file": "jinstall-ppc.tgz",
+                    "message": "",
+                },
+            },
+            {
+                "hostname": "rt2",
+                "model": "EX2300",
+                "connect": {"ok": True, "message": "connected"},
+                "local": {
+                    "status": "ok",
+                    "cached": False,
+                    "file": "junos-arm.tgz",
+                    "message": "",
+                },
+                "remote": {
+                    "status": "missing",
+                    "cached": False,
+                    "file": "junos-arm.tgz",
+                    "message": "  - remote package: junos-arm.tgz is not found.",
+                },
+            },
+        ]
+        out = display.format_check_table(
+            rows, show_connect=True, show_local=True, show_remote=True
+        )
+        assert "ok(cached)" in out
+        assert "missing" in out
+        assert "jinstall-ppc.tgz" in out
+        assert "rt2: remote:" in out  # detail line
+
+    def test_empty_rows_renders_header(self):
+        out = display.format_check_table(
+            [], show_connect=True, show_local=False, show_remote=False
+        )
+        assert out.startswith("hostname")
+        assert "connect" in out

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -135,7 +135,6 @@ class TestCheckHostWorker:
         ):
             result = cli._check_host("test-host")
         assert result["connect"]["ok"] is True
-        assert result["local"] is None
         assert result["remote"] is None
         assert result["model"] == "EX2300-24T"
         assert result["model_source"] == "device"
@@ -158,44 +157,6 @@ class TestCheckHostWorker:
         assert result["connect"]["ok"] is False
         assert result["connect"]["error"] == "ConnectTimeoutError"
         assert result["model"] is None
-
-    def test_local_only_uses_explicit_model(self, mock_config):
-        """--local --model MODEL skips NETCONF entirely."""
-        common.args = _make_check_args(
-            check_local=True, check_model="EX2300-24T"
-        )
-        with patch.object(common, "connect") as mock_conn, patch.object(
-            junos_upgrade_mod,
-            "check_local_package_by_model",
-            return_value={"status": "ok", "file": "pkg", "cached": False},
-        ) as mock_chk:
-            result = cli._check_host("test-host")
-        mock_conn.assert_not_called()
-        mock_chk.assert_called_once_with("test-host", "EX2300-24T")
-        assert result["local"]["status"] == "ok"
-        assert result["model_source"] == "cli"
-
-    def test_local_only_from_config_model(self, mock_config):
-        """--local reads model from config.ini [host].model when --model absent."""
-        common.config.set("test-host", "model", "EX2300-24T")
-        common.args = _make_check_args(check_local=True)
-        with patch.object(common, "connect") as mock_conn, patch.object(
-            junos_upgrade_mod,
-            "check_local_package_by_model",
-            return_value={"status": "ok", "file": "pkg", "cached": False},
-        ):
-            result = cli._check_host("test-host")
-        mock_conn.assert_not_called()
-        assert result["model_source"] == "config"
-        assert result["model"] == "EX2300-24T"
-
-    def test_local_unchecked_when_model_unknown(self, mock_config):
-        common.args = _make_check_args(check_local=True)
-        with patch.object(common, "connect") as mock_conn:
-            result = cli._check_host("test-host")
-        mock_conn.assert_not_called()
-        assert result["local"]["status"] == "unchecked"
-        assert "model unknown" in result["local"]["message"]
 
     def test_remote_unchecked_when_connect_fails(self, mock_config):
         common.args = _make_check_args(
@@ -221,6 +182,76 @@ class TestCheckHostWorker:
 # -------------------------------------------------------------------
 # display.format_check_table
 # -------------------------------------------------------------------
+
+
+class TestCheckLocalInventory:
+    def test_iterates_default_models(self, mock_config, tmp_path):
+        """All `<model>.file` pairs in DEFAULT are checked, regardless of host list."""
+        common.config.set("DEFAULT", "lpath", str(tmp_path))
+        common.config.set("DEFAULT", "ex4300-32f.file", "pkg-ex4300.tgz")
+        common.config.set("DEFAULT", "ex4300-32f.hash", "deadbeef")
+        common.args = _make_check_args(check_local=True)
+
+        with patch.object(
+            junos_upgrade_mod,
+            "check_local_package_by_model",
+            side_effect=lambda h, m: {
+                "file": f"pkg-{m}.tgz",
+                "local_file": f"{tmp_path}/pkg-{m}.tgz",
+                "status": "missing",
+                "cached": False,
+                "actual_hash": None,
+                "expected_hash": "deadbeef",
+                "message": f"  - local package: {tmp_path}/pkg-{m}.tgz is not found.",
+                "error": None,
+            },
+        ) as mock_chk:
+            rows = cli._check_local_inventory()
+
+        models_checked = [call.args[1] for call in mock_chk.call_args_list]
+        assert "ex2300-24t" in models_checked
+        assert "ex4300-32f" in models_checked
+        assert all(r["status"] == "missing" for r in rows)
+        # Section passed to the core is always "DEFAULT" in inventory mode.
+        assert all(call.args[0] == "DEFAULT" for call in mock_chk.call_args_list)
+
+    def test_model_filter(self, mock_config):
+        """--model X restricts inventory to the requested model only."""
+        common.args = _make_check_args(check_local=True, check_model="EX2300-24T")
+        with patch.object(
+            junos_upgrade_mod,
+            "check_local_package_by_model",
+            return_value={"status": "ok", "file": "pkg", "cached": False},
+        ) as mock_chk:
+            rows = cli._check_local_inventory()
+        mock_chk.assert_called_once_with("DEFAULT", "EX2300-24T")
+        assert len(rows) == 1
+
+    def test_format_inventory(self):
+        rows = [
+            {
+                "model": "ex2300-24t",
+                "file": "junos-arm.tgz",
+                "local_file": "/opt/fw/junos-arm.tgz",
+                "status": "ok",
+                "cached": True,
+            },
+            {
+                "model": "mx5-t",
+                "file": "jinstall-ppc.tgz",
+                "local_file": "/opt/fw/jinstall-ppc.tgz",
+                "status": "missing",
+                "cached": False,
+                "message": "  - local package: /opt/fw/jinstall-ppc.tgz is not found.",
+            },
+        ]
+        out = display.format_check_local_inventory(rows)
+        assert "model" in out.splitlines()[0]
+        assert "ok(cached)" in out
+        assert "missing" in out
+        # Detail line for missing entry surfaces the filename.
+        assert "mx5-t:" in out
+        assert "is not found" in out
 
 
 class TestFormatCheckTable:

--- a/tests/test_package_checks.py
+++ b/tests/test_package_checks.py
@@ -45,24 +45,22 @@ class TestCheckLocalPackage:
 
     def test_checksum_ok(self, junos_upgrade, mock_args, mock_config, capsys):
         """Fresh checksum matches: status=ok, cached=False."""
-        # Ensure no cache hit
-        junos_upgrade.common.config.set("localhost" if junos_upgrade.common.config.has_section("localhost") else "test-host", "dummy", "dummy") if False else None
-        mock_sw = MagicMock()
-        mock_sw.local_checksum.return_value = "abc123def456"
-        with patch.object(junos_upgrade, "SW", return_value=mock_sw):
+        with patch.object(
+            junos_upgrade, "_compute_local_checksum", return_value="abc123def456"
+        ) as mock_chk:
             result = junos_upgrade.check_local_package("test-host", self._dev())
         assert result["status"] == "ok"
         assert result["cached"] is False
         assert result["actual_hash"] == "abc123def456"
         assert "checksum is OK" in result["message"]
-        mock_sw.local_checksum.assert_called_once()
+        mock_chk.assert_called_once()
         assert capsys.readouterr().out == ""
 
     def test_checksum_bad(self, junos_upgrade, mock_args, mock_config, capsys):
         """Fresh checksum mismatches: status=bad."""
-        mock_sw = MagicMock()
-        mock_sw.local_checksum.return_value = "WRONG_HASH"
-        with patch.object(junos_upgrade, "SW", return_value=mock_sw):
+        with patch.object(
+            junos_upgrade, "_compute_local_checksum", return_value="WRONG_HASH"
+        ):
             result = junos_upgrade.check_local_package("test-host", self._dev())
         assert result["status"] == "bad"
         assert result["actual_hash"] == "WRONG_HASH"
@@ -72,9 +70,11 @@ class TestCheckLocalPackage:
 
     def test_file_missing(self, junos_upgrade, mock_args, mock_config, capsys):
         """FileNotFoundError: status=missing, actual_hash=None."""
-        mock_sw = MagicMock()
-        mock_sw.local_checksum.side_effect = FileNotFoundError("no such file")
-        with patch.object(junos_upgrade, "SW", return_value=mock_sw):
+        with patch.object(
+            junos_upgrade,
+            "_compute_local_checksum",
+            side_effect=FileNotFoundError("no such file"),
+        ):
             result = junos_upgrade.check_local_package("test-host", self._dev())
         assert result["status"] == "missing"
         assert result["actual_hash"] is None
@@ -83,9 +83,11 @@ class TestCheckLocalPackage:
 
     def test_generic_error(self, junos_upgrade, mock_args, mock_config, capsys):
         """Unexpected exception: status=error, error=ClassName."""
-        mock_sw = MagicMock()
-        mock_sw.local_checksum.side_effect = OSError("IO broken")
-        with patch.object(junos_upgrade, "SW", return_value=mock_sw):
+        with patch.object(
+            junos_upgrade,
+            "_compute_local_checksum",
+            side_effect=OSError("IO broken"),
+        ):
             result = junos_upgrade.check_local_package("test-host", self._dev())
         assert result["status"] == "error"
         assert result["error"] == "OSError"


### PR DESCRIPTION
## Summary
- Unified `check` subcommand with `--connect` / `--local` / `--remote` / `--all` flags, aligned-table output, and non-zero exit on any failure
- Scope widened from the original #41 proposal (device-less `check-local`) after in-session design discussion — `--remote` doubles as "did SCP copy fully land" verification, `--connect` fills the "just verify reachability" gap
- Device-less core: `check_local_package_by_model` uses `hashlib` directly, no PyEZ `SW` dependency required; existing `check_local_package(hostname, dev)` is now a thin wrapper
- Model resolution: `--model MODEL` > `config.ini [host].model` (new optional key) > `dev.facts["model"]`
- Version bump 0.14.1 → 0.15.0 (new feature)

## Test plan
- [x] `pytest tests/` — 252 passed (13 new in `tests/test_check.py`, existing `tests/test_package_checks.py` updated for the hashlib-based core)
- [x] `python -m build --wheel` — succeeds as `junos_ops-0.15.0-py3-none-any.whl`
- [x] `junos-ops check --help` renders
- [ ] Real-device smoke test (blocked on access)

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)