### PR TITLE
feat: ssh_config passthrough for jumphost access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ sshkey = id_ed25519   # SSH秘密鍵ファイル
 port = 830            # NETCONFポート
 hashalgo = md5        # チェックサムアルゴリズム
 rpath = /var/tmp      # リモートパス
+# ssh_config = ~/.ssh/config    # OpenSSH 互換設定（ProxyCommand 等）。未指定時は PyEZ が ~/.ssh/config を自動参照
 # lpath = ~/firmware            # ローカルのファームウェア置き場（~ 展開対応、デフォルト: カレントディレクトリ）
 # huge_tree = true    # 大きなXMLレスポンスを許可
 # RSI_DIR = ./rsi/    # RSI/SCFファイル出力先

--- a/README.ja.md
+++ b/README.ja.md
@@ -134,6 +134,7 @@ sshkey = id_ed25519   # SSH秘密鍵ファイル
 port = 830            # NETCONFポート
 hashalgo = md5        # チェックサムアルゴリズム
 rpath = /var/tmp      # リモートパス
+# ssh_config = ~/.ssh/config    # OpenSSH 互換設定（ProxyCommand 等）。未指定時は PyEZ が ~/.ssh/config を自動参照
 # lpath = ~/firmware            # ローカルのファームウェア置き場（~ 展開対応、デフォルト: カレントディレクトリ）
 # huge_tree = true    # 大きなXMLレスポンスを許可
 # RSI_DIR = ./rsi/    # RSI/SCFファイルの出力先
@@ -161,6 +162,7 @@ tags = osaka, core
 [sw1.example.jp]
 id = sw1                     # 接続ユーザを変更
 sshkey = sw1_rsa             # SSH鍵を変更
+ssh_config = ~/.ssh/config.lab   # ホスト別の OpenSSH 設定（bastion 等）
 tags = tokyo, access
 [sw2.example.jp]
 port = 10830                 # ポートを変更

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ sshkey = id_ed25519   # SSH private key file
 port = 830            # NETCONF port
 hashalgo = md5        # Checksum algorithm
 rpath = /var/tmp      # Remote path
+# ssh_config = ~/.ssh/config   # OpenSSH config (ProxyCommand etc.); if unset, PyEZ auto-picks up ~/.ssh/config
 # lpath = ~/firmware   # Local firmware directory (~ expanded, default: current directory)
 # huge_tree = true    # Allow large XML responses
 # RSI_DIR = ./rsi/    # Output directory for RSI/SCF files
@@ -161,6 +162,7 @@ tags = osaka, core
 [sw1.example.jp]
 id = sw1                     # Override SSH username
 sshkey = sw1_rsa             # Override SSH key
+ssh_config = ~/.ssh/config.lab   # Per-host OpenSSH config (e.g. behind a bastion)
 tags = tokyo, access
 [sw2.example.jp]
 port = 10830                 # Override port

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -116,15 +116,21 @@ def connect(
     """
     logger.debug("connect: start")
     host = config.get(hostname, "host")
-    dev = Device(
-        host=host,
-        port=int(config.get(hostname, "port")),
-        user=config.get(hostname, "id"),
-        passwd=config.get(hostname, "pw"),
-        ssh_private_key_file=os.path.expanduser(config.get(hostname, "sshkey")),
-        huge_tree=config.getboolean(hostname, "huge_tree", fallback=False),
-        gather_facts=gather_facts,
-    )
+    kwargs = {
+        "host": host,
+        "port": int(config.get(hostname, "port")),
+        "user": config.get(hostname, "id"),
+        "passwd": config.get(hostname, "pw"),
+        "ssh_private_key_file": os.path.expanduser(config.get(hostname, "sshkey")),
+        "huge_tree": config.getboolean(hostname, "huge_tree", fallback=False),
+        "gather_facts": gather_facts,
+    }
+    # Pass ssh_config only when the operator sets it; leaving it out preserves
+    # PyEZ/paramiko's implicit ~/.ssh/config auto-pickup.
+    ssh_config_path = config.get(hostname, "ssh_config", fallback=None)
+    if ssh_config_path:
+        kwargs["ssh_config"] = os.path.expanduser(ssh_config_path)
+    dev = Device(**kwargs)
     _ERROR_PREFIX = {
         ConnectAuthError: "Authentication credentials fail to login",
         ConnectRefusedError: "NETCONF Connection refused",

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -32,6 +32,31 @@ class TestConnect:
             captured = capsys.readouterr()
             assert captured.out == ""
 
+    def test_ssh_config_passthrough(self, junos_common, mock_args, mock_config, capsys):
+        """ssh_config is expanded with ~ and forwarded to Device."""
+        import os
+
+        mock_config.set("test-host", "ssh_config", "~/.ssh/config")
+        with patch.object(junos_common, "Device") as MockDevice:
+            MockDevice.return_value = MagicMock()
+
+            junos_common.connect("test-host")
+
+            assert MockDevice.call_args.kwargs["ssh_config"] == os.path.expanduser(
+                "~/.ssh/config"
+            )
+            assert capsys.readouterr().out == ""
+
+    def test_ssh_config_absent(self, junos_common, mock_args, mock_config, capsys):
+        """Without ssh_config set, no kwarg is passed so PyEZ's default applies."""
+        with patch.object(junos_common, "Device") as MockDevice:
+            MockDevice.return_value = MagicMock()
+
+            junos_common.connect("test-host")
+
+            assert "ssh_config" not in MockDevice.call_args.kwargs
+            assert capsys.readouterr().out == ""
+
     def _assert_error(self, result, exc_name):
         assert result["ok"] is False
         assert result["dev"] is None

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,5 +1,6 @@
 """connect() のモックテスト（dict 返却）"""
 
+import os
 from unittest.mock import patch, MagicMock
 
 from jnpr.junos.exception import (
@@ -33,18 +34,19 @@ class TestConnect:
             assert captured.out == ""
 
     def test_ssh_config_passthrough(self, junos_common, mock_args, mock_config, capsys):
-        """ssh_config is expanded with ~ and forwarded to Device."""
-        import os
-
+        """ssh_config is expanded with ~ and forwarded alongside existing kwargs."""
         mock_config.set("test-host", "ssh_config", "~/.ssh/config")
         with patch.object(junos_common, "Device") as MockDevice:
             MockDevice.return_value = MagicMock()
 
             junos_common.connect("test-host")
 
-            assert MockDevice.call_args.kwargs["ssh_config"] == os.path.expanduser(
-                "~/.ssh/config"
-            )
+            kw = MockDevice.call_args.kwargs
+            assert kw["ssh_config"] == os.path.expanduser("~/.ssh/config")
+            # Existing kwargs must survive the refactor to a kwargs dict.
+            assert kw["host"] == "192.0.2.1"
+            assert kw["port"] == 830
+            assert kw["user"] == "testuser"
             assert capsys.readouterr().out == ""
 
     def test_ssh_config_absent(self, junos_common, mock_args, mock_config, capsys):


### PR DESCRIPTION
## Summary
- Closes #43. Adds `ssh_config` key to `config.ini` (DEFAULT or per-host), forwarded to `jnpr.junos.Device(ssh_config=...)` with `~` expansion.
- When unset, no kwarg is passed — PyEZ/paramiko keep the implicit `~/.ssh/config` auto-pickup.
- README (en/ja) + CLAUDE.md updated with a commented example and a per-host override example.

## Test plan
- [x] `pytest tests/test_connect.py` — 8 passed (2 new: `test_ssh_config_passthrough`, `test_ssh_config_absent`)
- [x] Full `pytest tests/` — 264 passed
- [ ] Real-device smoke test against a host behind ProxyCommand (manual, with WireGuard up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)