### PR TITLE
feat: show subcommand gains --format text|json|xml (#44 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ junos_ops/
 ├── cli.py          # サブコマンドルーティング、argparse、main()
 ├── common.py       # 共通機能（設定読込、接続管理、ターゲット決定、並列実行）
 ├── upgrade.py      # upgrade系機能（コピー、インストール、ロールバック、バージョン管理）
+├── show.py         # show サブコマンド core（run_cli / run_cli_batch、text|json|xml）
 └── rsi.py          # RSI/SCF収集機能
 tests/
 ├── conftest.py     # pytest フィクスチャ
@@ -81,9 +82,16 @@ LICENSE
 - すべての core 関数は stdout に print しない。人間向け整形は `display` 層が担う。
 
 ### display.py — 表示層
-- `print_version()`, `print_copy()`, `print_install()`, `print_rollback()`, `print_reboot()`, `print_reinstall()`, `print_load_config()`, `print_list_remote()`, `print_dry_run()`, `print_rsi()`, `print_connect_error()`, `print_read_config_error()`, `print_host_header()`, `print_host_footer()` — core が返す dict を人間向けに整形
+- `print_version()`, `print_copy()`, `print_install()`, `print_rollback()`, `print_reboot()`, `print_reinstall()`, `print_load_config()`, `print_list_remote()`, `print_dry_run()`, `print_rsi()`, `print_show()`, `print_connect_error()`, `print_read_config_error()`, `print_host_header()`, `print_host_footer()` — core が返す dict を人間向けに整形
 - `_print_lock` (`threading.Lock`) でマルチワーカー時の出力インターリーブを防止
 - junos-mcp など非 CLI 利用者は display を import しなければ stdout 出力ゼロ
+
+### show.py — show サブコマンド core（すべて dict を返す）
+- `run_cli(dev, command, *, output_format="text", retry=0, hostname="")` — 単一コマンド実行。`format=text`→`dev.cli(cmd)`（string）、`json`→`dev.cli(cmd, format="json")`（dict）、`xml`→`dev.cli(cmd, format="xml")` の lxml を pretty-print 文字列化
+- `run_cli_batch(dev, commands, ...)` — `-f FILE` 用。最初の失敗で短絡
+- `_cli_with_retry()` — `RpcTimeoutError` 時のバックオフ付きリトライ（5秒, 10秒, 15秒, ...）
+- `VALID_FORMATS` — `("text", "json", "xml")`
+- Caveat: NETCONF は `json` / `xml` 取得時に `| match` / `| last` / `| count` などのパイプ段を落とす。フィルタしたいときは `text` かつシェル側で加工
 
 ### rsi.py — RSI/SCF収集
 - RSI = request support information
@@ -108,7 +116,7 @@ junos-ops rollback [hostname ...]          # ロールバック
 junos-ops version [hostname ...]           # バージョン表示
 junos-ops reboot --at YYMMDDHHMM [hostname ...]  # リブート
 junos-ops ls [-l] [hostname ...]           # リモートファイル一覧
-junos-ops show COMMAND [hostname ...]           # 任意の CLI コマンドを実行
+junos-ops show COMMAND [-F text|json|xml] [hostname ...]   # 任意の CLI コマンドを実行（-F で構造化出力）
 junos-ops config -f FILE [--confirm N] [hostname ...]  # set コマンドファイル適用
 junos-ops check [--connect|--local|--remote|--all] [--model M] [hostname ...]  # pre-flight チェック
 junos-ops rsi [hostname ...]               # RSI/SCF収集

--- a/README.ja.md
+++ b/README.ja.md
@@ -537,7 +537,22 @@ show security flow session summary
 % junos-ops show "show system alarms" --retry 2 --workers 10 --config accounts.ini
 ```
 
-> **注意:** JUNOS CLI のパイプフィルタ（`| match`、`| count` 等）は使用できません。PyEZ の `dev.cli()` は NETCONF RPC 経由でコマンドを送信するため、パイプ修飾子は処理されません。出力のフィルタにはシェル側のツール（`grep` 等）を使用してください。
+#### 構造化出力（`--format`）
+
+`-F` / `--format {text,json,xml}` で出力形式を切り替えられます。`text` が既定（従来動作）、`json` はプログラム／AI アシスタント向け、`xml` は RPC 応答を pretty-print して返します。
+
+```
+% junos-ops show "show interfaces terse" --format json gw1.example.jp
+# gw1.example.jp
+## show interfaces terse
+{
+  "interface-information": {
+    "physical-interface": [ ... ]
+  }
+}
+```
+
+> **注意 — `json` / `xml` ではパイプ段が落ちる。** NETCONF 経由で `json`／`xml` を要求すると、`| match`、`| last`、`| count` などのパイプ修飾子はデバイス側で暗黙に落とされます（[Juniper/junos-mcp-server#4](https://github.com/Juniper/junos-mcp-server/issues/4)／[#12](https://github.com/Juniper/junos-mcp-server/issues/12) 参照）。`--format text` なら従来どおりパイプ段は有効です。構造化出力をフィルタしたいときは `text` のままシェル側（`jc` / `grep` / 後段の `jq` 等）で加工するか、対応する RPC を直接呼び出してください。
 
 ### 引数なし（デバイスファクト表示）
 

--- a/README.md
+++ b/README.md
@@ -552,7 +552,22 @@ Use `--retry N` to retry commands that fail with `RpcTimeoutError` (with increme
 % junos-ops show "show system alarms" --retry 2 --workers 10 --config accounts.ini
 ```
 
-> **Note:** JUNOS CLI pipe filters (`| match`, `| count`, etc.) are not supported. PyEZ's `dev.cli()` sends commands via NETCONF RPC, which does not process pipe modifiers. Filter output with shell tools (e.g. `grep`) instead.
+#### Structured output (`--format`)
+
+Use `-F` / `--format {text,json,xml}` to change the output format. `text` is the default (legacy behaviour); `json` is handy for programmatic consumers and AI assistants; `xml` returns the pretty-printed RPC reply.
+
+```
+% junos-ops show "show interfaces terse" --format json gw1.example.jp
+# gw1.example.jp
+## show interfaces terse
+{
+  "interface-information": {
+    "physical-interface": [ ... ]
+  }
+}
+```
+
+> **Caveat — pipe stages with `json` / `xml`.** Over NETCONF, pipe modifiers like `| match`, `| last`, and `| count` are silently dropped when the device is asked to emit `json` or `xml` (see [Juniper/junos-mcp-server#4](https://github.com/Juniper/junos-mcp-server/issues/4) / [#12](https://github.com/Juniper/junos-mcp-server/issues/12)). They are honoured for `--format text`. If you need to filter structured output, either stay on `text` and pipe through shell tools (e.g. `jc`, `grep`, `jq` after a separate parse step) or call the equivalent RPC directly.
 
 ### No subcommand (show device facts)
 

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -15,12 +15,11 @@
 
 """CLI entry point and subcommand routing for junos-ops."""
 
-from jnpr.junos.exception import ConnectClosedError, RpcTimeoutError
+from jnpr.junos.exception import ConnectClosedError
 from pprint import pprint
 import argparse
 import io
 import sys
-import time
 import logging
 import logging.config
 import os
@@ -56,6 +55,7 @@ from junos_ops import common  # noqa: E402
 from junos_ops import display  # noqa: E402
 from junos_ops import upgrade  # noqa: E402
 from junos_ops import rsi  # noqa: E402
+from junos_ops import show  # noqa: E402
 
 
 # --- サブコマンド用エントリ関数 ---
@@ -218,52 +218,33 @@ def cmd_reboot(hostname) -> int:
             pass
 
 
-def _cli_with_retry(dev, command, hostname, max_retries):
-    """Execute CLI command with retry on RpcTimeoutError.
-
-    :param max_retries: Number of retries (0 = no retry).
-    :raises: RpcTimeoutError if all retries exhausted.
-    """
-    for attempt in range(max_retries + 1):
-        try:
-            return dev.cli(command)
-        except RpcTimeoutError:
-            if attempt < max_retries:
-                wait = 5 * (attempt + 1)
-                logger.warning(
-                    f"{hostname}: RpcTimeoutError, "
-                    f"retry {attempt + 1}/{max_retries} in {wait}s"
-                )
-                time.sleep(wait)
-            else:
-                raise
-
-
 def cmd_show(hostname) -> int:
-    """Run CLI command on device and print output."""
+    """Run CLI command on device and print output via display layer."""
     dev = _open_connection(hostname)
     if dev is None:
         return 1
     retry = getattr(common.args, "retry", 0)
+    output_format = getattr(common.args, "show_format", "text") or "text"
     try:
         if common.args.showfile:
-            # ファイルから複数コマンドを読み込み、1セッション内で順次実行
             commands = common.load_commands(common.args.showfile)
-            lines = []
-            for cmd in commands:
-                output = _cli_with_retry(dev, cmd, hostname, retry)
-                lines.append(f"## {cmd}\n{output.strip()}")
-            print(f"# {hostname}\n" + "\n\n".join(lines) + "\n")
-        else:
-            output = _cli_with_retry(
-                dev, common.args.show_command, hostname, retry
+            result = show.run_cli_batch(
+                dev,
+                commands,
+                output_format=output_format,
+                retry=retry,
+                hostname=hostname,
             )
-            # 1回の print で出力し、並列実行時のインターリーブを軽減
-            print(f"# {hostname}\n{output.strip()}\n")
-        return 0
-    except Exception as e:
-        logger.error(f"{hostname}: {e}")
-        return 1
+        else:
+            result = show.run_cli(
+                dev,
+                common.args.show_command,
+                output_format=output_format,
+                retry=retry,
+                hostname=hostname,
+            )
+        display.print_show(result)
+        return 0 if result["ok"] else 1
     finally:
         try:
             dev.close()
@@ -654,6 +635,15 @@ def _run():
         help="path to file containing CLI commands (one per line)",
     )
     p_show.add_argument(
+        "-F", "--format", dest="show_format",
+        choices=list(show.VALID_FORMATS), default="text",
+        help=(
+            "output format: text (default), json, or xml. "
+            "Note: '| match' / '| last' pipe stages are dropped by NETCONF "
+            "under json/xml; use text (or an RPC) when you need to filter."
+        ),
+    )
+    p_show.add_argument(
         "--retry", type=int, default=0,
         help="number of retries on RpcTimeoutError (default: 0)",
     )
@@ -816,6 +806,8 @@ def _run():
         args.show_command = None
     if not hasattr(args, "showfile"):
         args.showfile = None
+    if not hasattr(args, "show_format"):
+        args.show_format = "text"
     if not hasattr(args, "tags"):
         args.tags = None
     if not hasattr(args, "retry"):

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -455,18 +455,17 @@ def print_rsi(result: dict) -> None:
 
 def _format_single_show(result: dict) -> str:
     """Render one ``show.run_cli`` result (body only, no host header)."""
+    command = result.get("command", "")
     if not result.get("ok"):
         err = result.get("error_message") or result.get("error") or "error"
-        return f"## {result.get('command', '')}\n{err}".rstrip()
+        return f"## {command}\n{err}".rstrip()
     fmt = result.get("format", "text")
     output = result.get("output")
     if fmt == "json":
         body = json.dumps(output, indent=2, ensure_ascii=False)
     else:
-        # text / xml are already strings; strip trailing whitespace to
-        # keep multi-command batches tidy.
-        body = (output or "").rstrip()
-    return f"## {result.get('command', '')}\n{body}"
+        body = output or ""
+    return f"## {command}\n{body}".rstrip()
 
 
 def format_show(result: dict) -> str:
@@ -476,15 +475,11 @@ def format_show(result: dict) -> str:
     ``output`` (single). Both layouts share the ``# hostname`` header
     followed by one or more ``## command`` blocks.
     """
-    hostname = result.get("hostname", "")
-    lines = [f"# {hostname}"]
+    header = format_host_header(result.get("hostname", ""))
     if "results" in result:
-        for sub in result["results"]:
-            lines.append(_format_single_show(sub))
-        body = "\n\n".join(lines[1:])
-        return f"{lines[0]}\n{body}\n"
-    lines.append(_format_single_show(result))
-    return "\n".join(lines) + "\n"
+        blocks = [_format_single_show(sub) for sub in result["results"]]
+        return f"{header}\n" + "\n\n".join(blocks) + "\n"
+    return f"{header}\n{_format_single_show(result)}\n"
 
 
 def print_show(result: dict) -> None:

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -39,6 +39,7 @@ Conventions:
       keys; programmatic consumers should strip them before serializing.
 """
 
+import json
 import threading
 from pprint import pformat
 
@@ -448,13 +449,47 @@ def print_rsi(result: dict) -> None:
 
 
 # -------------------------------------------------------------------
-# show (not yet migrated)
+# show
 # -------------------------------------------------------------------
 
 
+def _format_single_show(result: dict) -> str:
+    """Render one ``show.run_cli`` result (body only, no host header)."""
+    if not result.get("ok"):
+        err = result.get("error_message") or result.get("error") or "error"
+        return f"## {result.get('command', '')}\n{err}".rstrip()
+    fmt = result.get("format", "text")
+    output = result.get("output")
+    if fmt == "json":
+        body = json.dumps(output, indent=2, ensure_ascii=False)
+    else:
+        # text / xml are already strings; strip trailing whitespace to
+        # keep multi-command batches tidy.
+        body = (output or "").rstrip()
+    return f"## {result.get('command', '')}\n{body}"
+
+
+def format_show(result: dict) -> str:
+    """Format a ``show.run_cli`` (single) or ``show.run_cli_batch`` result.
+
+    The dict shape is detected by the presence of ``results`` (batch) vs
+    ``output`` (single). Both layouts share the ``# hostname`` header
+    followed by one or more ``## command`` blocks.
+    """
+    hostname = result.get("hostname", "")
+    lines = [f"# {hostname}"]
+    if "results" in result:
+        for sub in result["results"]:
+            lines.append(_format_single_show(sub))
+        body = "\n\n".join(lines[1:])
+        return f"{lines[0]}\n{body}\n"
+    lines.append(_format_single_show(result))
+    return "\n".join(lines) + "\n"
+
+
 def print_show(result: dict) -> None:
-    """Print ``cmd_show`` result (a list of command/output pairs)."""
-    raise NotImplementedError
+    """Print ``show.run_cli`` / ``run_cli_batch`` result atomically."""
+    _emit(format_show(result))
 
 
 # -------------------------------------------------------------------

--- a/junos_ops/show.py
+++ b/junos_ops/show.py
@@ -1,0 +1,167 @@
+"""CLI passthrough for ``junos-ops show``: text / json / xml formats.
+
+Core functions here return plain ``dict`` values without touching stdout;
+the :mod:`junos_ops.display` layer renders them for terminals, while
+non-CLI consumers (e.g. ``junos-mcp``) can feed the dicts into their own
+serializers.
+
+The three formats map to PyEZ as follows:
+
+- ``text`` -> ``dev.cli(command)`` returns a string (default, legacy behaviour)
+- ``json`` -> ``dev.cli(command, format="json")`` returns a Python ``dict``
+  parsed from the device's ``| display json`` output
+- ``xml``  -> ``dev.cli(command, format="xml")`` returns an ``lxml._Element``
+  which we serialise with pretty-printing
+
+NETCONF note: pipe stages such as ``| match`` and ``| last`` are dropped
+by the device when the caller asks for ``format=json|xml``. Callers that
+need to filter output should use ``format=text`` or call the equivalent
+RPC directly.
+"""
+
+import time
+from logging import getLogger
+
+from jnpr.junos.exception import RpcTimeoutError
+from lxml import etree
+
+logger = getLogger(__name__)
+
+VALID_FORMATS = ("text", "json", "xml")
+
+
+def _cli_with_retry(
+    dev, command: str, hostname: str, retry: int, output_format: str
+):
+    """Call ``dev.cli`` with the given format, retrying on RpcTimeoutError.
+
+    :raises RpcTimeoutError: once the retry budget is exhausted.
+    """
+    kwargs = {} if output_format == "text" else {"format": output_format}
+    for attempt in range(retry + 1):
+        try:
+            return dev.cli(command, **kwargs)
+        except RpcTimeoutError:
+            if attempt < retry:
+                wait = 5 * (attempt + 1)
+                logger.warning(
+                    f"{hostname}: RpcTimeoutError, "
+                    f"retry {attempt + 1}/{retry} in {wait}s"
+                )
+                time.sleep(wait)
+            else:
+                raise
+
+
+def _normalise_output(raw, output_format: str):
+    """Convert the PyEZ return value into a display-friendly payload.
+
+    - ``text``: already a string, returned as-is
+    - ``json``: already a ``dict``, returned as-is
+    - ``xml``:  lxml ``_Element``, serialised with ``pretty_print=True``
+    """
+    if output_format == "xml":
+        return etree.tostring(raw, pretty_print=True, encoding="unicode")
+    return raw
+
+
+def run_cli(
+    dev,
+    command: str,
+    *,
+    output_format: str = "text",
+    retry: int = 0,
+    hostname: str = "",
+) -> dict:
+    """Run a single CLI command and return a dict describing the outcome.
+
+    :param dev: open PyEZ ``Device``.
+    :param command: CLI command string (e.g. ``"show version"``).
+    :param output_format: ``text`` (default), ``json``, or ``xml``.
+    :param retry: number of retries on ``RpcTimeoutError`` (0 = no retry).
+    :param hostname: config section name, used in log messages and echoed
+        back in the result.
+    :return: dict with keys:
+
+        - ``hostname`` (str)
+        - ``command`` (str)
+        - ``format`` (str): echoed back for display / downstream consumers.
+        - ``ok`` (bool)
+        - ``output``: ``str`` (text / xml) or ``dict`` (json) on success,
+          ``None`` on failure.
+        - ``error`` (str | None): exception class name on failure.
+        - ``error_message`` (str | None)
+
+    Does not print.
+    """
+    if output_format not in VALID_FORMATS:
+        raise ValueError(
+            f"invalid format {output_format!r}; "
+            f"expected one of {VALID_FORMATS}"
+        )
+    try:
+        raw = _cli_with_retry(dev, command, hostname, retry, output_format)
+        return {
+            "hostname": hostname,
+            "command": command,
+            "format": output_format,
+            "ok": True,
+            "output": _normalise_output(raw, output_format),
+            "error": None,
+            "error_message": None,
+        }
+    except Exception as e:
+        logger.error(f"{hostname}: {e}")
+        return {
+            "hostname": hostname,
+            "command": command,
+            "format": output_format,
+            "ok": False,
+            "output": None,
+            "error": type(e).__name__,
+            "error_message": str(e),
+        }
+
+
+def run_cli_batch(
+    dev,
+    commands: list[str],
+    *,
+    output_format: str = "text",
+    retry: int = 0,
+    hostname: str = "",
+) -> dict:
+    """Run a list of CLI commands in one session, short-circuiting on failure.
+
+    Stops at the first command that fails (typically a connection drop
+    makes subsequent commands pointless). Returns the partial result list
+    so callers can see which command broke.
+
+    :return: dict with keys:
+
+        - ``hostname`` (str)
+        - ``format`` (str)
+        - ``ok`` (bool): True when every command succeeded.
+        - ``results`` (list[dict]): per-command :func:`run_cli` dicts
+          up to and including the first failure.
+
+    Does not print.
+    """
+    results: list[dict] = []
+    for cmd in commands:
+        res = run_cli(
+            dev,
+            cmd,
+            output_format=output_format,
+            retry=retry,
+            hostname=hostname,
+        )
+        results.append(res)
+        if not res["ok"]:
+            break
+    return {
+        "hostname": hostname,
+        "format": output_format,
+        "ok": all(r["ok"] for r in results) and len(results) == len(commands),
+        "results": results,
+    }

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,337 +1,375 @@
-"""show サブコマンドのテスト"""
+"""Tests for the show subcommand and the junos_ops.show core."""
 
 from unittest.mock import MagicMock, patch, call
-from jnpr.junos.exception import RpcTimeoutError
 
-from junos_ops import cli
-from junos_ops import common
+import pytest
+from jnpr.junos.exception import RpcTimeoutError
+from lxml import etree
+
+from junos_ops import cli, common, display, show
+
+
+CONNECT_OK = {
+    "hostname": "test-host",
+    "host": "test-host",
+    "ok": True,
+    "dev": None,
+    "error": None,
+    "error_message": None,
+}
+CONNECT_FAIL = {
+    "hostname": "test-host",
+    "host": "test-host",
+    "ok": False,
+    "dev": None,
+    "error": "ConnectError",
+    "error_message": "mock connect error",
+}
+
+
+def _connect_ok(dev):
+    return {**CONNECT_OK, "dev": dev}
+
+
+class TestRunCli:
+    """show.run_cli() returns a dict describing the outcome."""
+
+    def test_text_success(self):
+        dev = MagicMock()
+        dev.cli.return_value = "output line\n"
+        result = show.run_cli(dev, "show version", hostname="h")
+        assert result["ok"] is True
+        assert result["command"] == "show version"
+        assert result["format"] == "text"
+        assert result["output"] == "output line\n"
+        assert result["error"] is None
+        dev.cli.assert_called_once_with("show version")
+
+    def test_json_passthrough(self):
+        dev = MagicMock()
+        dev.cli.return_value = {"interface-information": {"physical-interface": []}}
+        result = show.run_cli(
+            dev, "show interfaces terse", output_format="json", hostname="h"
+        )
+        assert result["ok"] is True
+        assert result["format"] == "json"
+        assert result["output"] == {
+            "interface-information": {"physical-interface": []}
+        }
+        dev.cli.assert_called_once_with(
+            "show interfaces terse", format="json"
+        )
+
+    def test_xml_pretty_printed(self):
+        dev = MagicMock()
+        dev.cli.return_value = etree.fromstring("<root><child>x</child></root>")
+        result = show.run_cli(
+            dev, "show version", output_format="xml", hostname="h"
+        )
+        assert result["ok"] is True
+        assert result["format"] == "xml"
+        # Serialised with pretty_print=True -> indented, str (not bytes).
+        assert isinstance(result["output"], str)
+        assert "<child>x</child>" in result["output"]
+        assert "\n" in result["output"]
+        dev.cli.assert_called_once_with("show version", format="xml")
+
+    def test_invalid_format_raises(self):
+        dev = MagicMock()
+        with pytest.raises(ValueError, match="invalid format"):
+            show.run_cli(dev, "show version", output_format="yaml")
+
+    def test_generic_exception_returns_error_dict(self):
+        dev = MagicMock()
+        dev.cli.side_effect = RuntimeError("boom")
+        result = show.run_cli(dev, "show version", hostname="h")
+        assert result["ok"] is False
+        assert result["output"] is None
+        assert result["error"] == "RuntimeError"
+        assert result["error_message"] == "boom"
+
+
+class TestRunCliRetry:
+    """show.run_cli retries RpcTimeoutError only."""
+
+    @patch("junos_ops.show.time.sleep")
+    def test_retry_then_success(self, mock_sleep):
+        dev = MagicMock()
+        dev.cli.side_effect = [
+            RpcTimeoutError(MagicMock(hostname="h"), "c", 30),
+            "ok",
+        ]
+        result = show.run_cli(dev, "show system alarms", retry=2, hostname="h")
+        assert result["ok"] is True
+        assert result["output"] == "ok"
+        assert dev.cli.call_count == 2
+        mock_sleep.assert_called_once_with(5)
+
+    @patch("junos_ops.show.time.sleep")
+    def test_retry_exhausted_returns_error(self, mock_sleep):
+        dev = MagicMock()
+        dev.cli.side_effect = RpcTimeoutError(
+            MagicMock(hostname="h"), "c", 30
+        )
+        result = show.run_cli(dev, "show ...", retry=2, hostname="h")
+        assert result["ok"] is False
+        assert result["error"] == "RpcTimeoutError"
+        assert dev.cli.call_count == 3  # first call + 2 retries
+        mock_sleep.assert_has_calls([call(5), call(10)])
+
+    def test_no_retry_default(self):
+        dev = MagicMock()
+        dev.cli.side_effect = RpcTimeoutError(
+            MagicMock(hostname="h"), "c", 30
+        )
+        result = show.run_cli(dev, "show ...", hostname="h")
+        assert result["ok"] is False
+        assert dev.cli.call_count == 1
+
+    @patch("junos_ops.show.time.sleep")
+    def test_non_timeout_not_retried(self, mock_sleep):
+        dev = MagicMock()
+        dev.cli.side_effect = RuntimeError("other")
+        result = show.run_cli(dev, "show ...", retry=3, hostname="h")
+        assert result["ok"] is False
+        assert result["error"] == "RuntimeError"
+        assert dev.cli.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+class TestRunCliBatch:
+    """show.run_cli_batch aggregates per-command results and short-circuits."""
+
+    def test_all_succeed(self):
+        dev = MagicMock()
+        dev.cli.side_effect = ["a", "b"]
+        result = show.run_cli_batch(
+            dev, ["show a", "show b"], hostname="h"
+        )
+        assert result["ok"] is True
+        assert [r["command"] for r in result["results"]] == ["show a", "show b"]
+        assert [r["output"] for r in result["results"]] == ["a", "b"]
+
+    def test_short_circuits_on_first_failure(self):
+        dev = MagicMock()
+        dev.cli.side_effect = [RuntimeError("boom"), "unreached"]
+        result = show.run_cli_batch(
+            dev, ["show a", "show b"], hostname="h"
+        )
+        assert result["ok"] is False
+        assert len(result["results"]) == 1
+        assert result["results"][0]["error"] == "RuntimeError"
+        # show b must not be attempted after show a fails.
+        assert dev.cli.call_count == 1
+
+
+class TestFormatShow:
+    """display.format_show renders text / json / xml appropriately."""
+
+    def test_text_single(self):
+        result = {
+            "hostname": "h",
+            "command": "show version",
+            "format": "text",
+            "ok": True,
+            "output": "  Model: MX204  \n",
+            "error": None,
+            "error_message": None,
+        }
+        out = display.format_show(result)
+        assert out.startswith("# h\n## show version\n")
+        assert "Model: MX204" in out
+
+    def test_json_single(self):
+        result = {
+            "hostname": "h",
+            "command": "show interfaces",
+            "format": "json",
+            "ok": True,
+            "output": {"greeting": "こんにちは"},
+            "error": None,
+            "error_message": None,
+        }
+        out = display.format_show(result)
+        # ensure_ascii=False preserves non-ASCII.
+        assert "こんにちは" in out
+        assert '"greeting"' in out
+
+    def test_batch_layout(self):
+        result = {
+            "hostname": "h",
+            "format": "text",
+            "ok": True,
+            "results": [
+                {
+                    "hostname": "h",
+                    "command": "show a",
+                    "format": "text",
+                    "ok": True,
+                    "output": "out-a",
+                    "error": None,
+                    "error_message": None,
+                },
+                {
+                    "hostname": "h",
+                    "command": "show b",
+                    "format": "text",
+                    "ok": True,
+                    "output": "out-b",
+                    "error": None,
+                    "error_message": None,
+                },
+            ],
+        }
+        out = display.format_show(result)
+        assert "# h" in out
+        assert "## show a" in out and "out-a" in out
+        assert "## show b" in out and "out-b" in out
+
+    def test_error_rendered(self):
+        result = {
+            "hostname": "h",
+            "command": "show x",
+            "format": "text",
+            "ok": False,
+            "output": None,
+            "error": "RpcTimeoutError",
+            "error_message": "timeout after 30s",
+        }
+        out = display.format_show(result)
+        assert "timeout after 30s" in out
 
 
 class TestCmdShow:
-    """cmd_show() のテスト"""
+    """Integration tests via cli.cmd_show."""
 
-    def test_connect_fail(self, junos_common, mock_args, mock_config):
-        """接続失敗時に 1 を返す"""
+    def test_connect_fail_returns_1(self, junos_common, mock_args, mock_config):
         mock_args.show_command = "show version"
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": False, "dev": None, "error": "ConnectError", "error_message": "mock connect error"}):
-            result = cli.cmd_show("test-host")
-            assert result == 1
+        with patch.object(cli.common, "connect", return_value=CONNECT_FAIL):
+            assert cli.cmd_show("test-host") == 1
 
-    def test_success(self, junos_common, mock_args, mock_config, capsys):
-        """正常時にホスト名付きで出力される"""
+    def test_text_success_prints_via_display(
+        self, junos_common, mock_args, mock_config, capsys
+    ):
         mock_args.show_command = "show version"
-        mock_dev = MagicMock()
-        mock_dev.cli.return_value = "  Hostname: test-host\nModel: MX204  \n"
+        mock_args.show_format = "text"
+        dev = MagicMock()
+        dev.cli.return_value = "Hostname: test-host\n"
+        with patch.object(cli.common, "connect", return_value=_connect_ok(dev)):
+            rc = cli.cmd_show("test-host")
+        assert rc == 0
+        dev.cli.assert_called_once_with("show version")
+        dev.close.assert_called_once()
+        captured = capsys.readouterr().out
+        assert "# test-host" in captured
+        assert "## show version" in captured
+        assert "Hostname: test-host" in captured
 
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-        mock_dev.cli.assert_called_once_with("show version")
-        mock_dev.close.assert_called_once()
-        captured = capsys.readouterr()
-        assert "# test-host" in captured.out
-        assert "Hostname: test-host" in captured.out
-        assert "Model: MX204" in captured.out
-
-    def test_exception(self, junos_common, mock_args, mock_config):
-        """dev.cli() 例外時に 1 を返す"""
-        mock_args.show_command = "show bgp summary"
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = Exception("RPC timeout")
-
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 1
-        mock_dev.close.assert_called_once()
-
-    def test_dev_close_on_exception(self, junos_common, mock_args, mock_config):
-        """例外時でも dev.close() が呼ばれる"""
+    def test_json_flag_passes_format_kwarg(
+        self, junos_common, mock_args, mock_config, capsys
+    ):
         mock_args.show_command = "show interfaces terse"
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = RuntimeError("unexpected")
+        mock_args.show_format = "json"
+        dev = MagicMock()
+        dev.cli.return_value = {"interface-information": {}}
+        with patch.object(cli.common, "connect", return_value=_connect_ok(dev)):
+            rc = cli.cmd_show("test-host")
+        assert rc == 0
+        dev.cli.assert_called_once_with("show interfaces terse", format="json")
+        assert '"interface-information"' in capsys.readouterr().out
 
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
+    def test_cli_exception_returns_1(self, junos_common, mock_args, mock_config):
+        mock_args.show_command = "show bgp summary"
+        mock_args.show_format = "text"
+        dev = MagicMock()
+        dev.cli.side_effect = Exception("RPC timeout")
+        with patch.object(cli.common, "connect", return_value=_connect_ok(dev)):
+            rc = cli.cmd_show("test-host")
+        assert rc == 1
+        dev.close.assert_called_once()
 
-        assert result == 1
-        mock_dev.close.assert_called_once()
-
-    def test_close_exception_suppressed(self, junos_common, mock_args, mock_config):
-        """dev.close() の例外が握り潰される"""
+    def test_dev_close_exception_suppressed(
+        self, junos_common, mock_args, mock_config
+    ):
         mock_args.show_command = "show version"
-        mock_dev = MagicMock()
-        mock_dev.cli.return_value = "output"
-        mock_dev.close.side_effect = Exception("close failed")
-
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-
-    def test_show_command_passed_to_cli(self, junos_common, mock_args, mock_config):
-        """args.show_command がそのまま dev.cli() に渡される"""
-        mock_args.show_command = "show configuration system login user nttview"
-        mock_dev = MagicMock()
-        mock_dev.cli.return_value = "user nttview { ... }"
-
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-        mock_dev.cli.assert_called_once_with(
-            "show configuration system login user nttview"
-        )
+        mock_args.show_format = "text"
+        dev = MagicMock()
+        dev.cli.return_value = "output"
+        dev.close.side_effect = Exception("close failed")
+        with patch.object(cli.common, "connect", return_value=_connect_ok(dev)):
+            assert cli.cmd_show("test-host") == 0
 
 
 class TestCmdShowFile:
-    """cmd_show() の -f ファイルモードのテスト"""
+    """cmd_show with -f FILE exercises run_cli_batch."""
 
-    def test_showfile_success(self, junos_common, mock_args, mock_config, capsys):
-        """複数コマンドファイルからの正常実行、出力フォーマット確認"""
+    def test_batch_success(self, junos_common, mock_args, mock_config, capsys):
         mock_args.showfile = "commands.txt"
         mock_args.show_command = None
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = [
-            "  terse output  ",
-            "  route summary  ",
-        ]
-
+        mock_args.show_format = "text"
+        dev = MagicMock()
+        dev.cli.side_effect = ["terse output", "route summary"]
         with (
-            patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}),
+            patch.object(cli.common, "connect", return_value=_connect_ok(dev)),
             patch.object(
-                cli.common, "load_commands",
+                cli.common,
+                "load_commands",
                 return_value=["show interfaces terse", "show route summary"],
             ),
         ):
-            result = cli.cmd_show("test-host")
+            rc = cli.cmd_show("test-host")
+        assert rc == 0
+        assert dev.cli.call_count == 2
+        out = capsys.readouterr().out
+        assert "## show interfaces terse" in out
+        assert "## show route summary" in out
 
-        assert result == 0
-        assert mock_dev.cli.call_count == 2
-        mock_dev.cli.assert_any_call("show interfaces terse")
-        mock_dev.cli.assert_any_call("show route summary")
-        mock_dev.close.assert_called_once()
-
-        captured = capsys.readouterr()
-        assert "# test-host" in captured.out
-        assert "## show interfaces terse" in captured.out
-        assert "terse output" in captured.out
-        assert "## show route summary" in captured.out
-        assert "route summary" in captured.out
-
-    def test_showfile_skips_comments_and_blanks(
-        self, junos_common, mock_args, mock_config, capsys
-    ):
-        """load_commands がコメント行と空行をスキップすることの確認"""
+    def test_batch_short_circuits(self, junos_common, mock_args, mock_config):
         mock_args.showfile = "commands.txt"
         mock_args.show_command = None
-        mock_dev = MagicMock()
-        mock_dev.cli.return_value = "output"
-
+        mock_args.show_format = "text"
+        dev = MagicMock()
+        dev.cli.side_effect = Exception("RPC timeout")
         with (
-            patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}),
+            patch.object(cli.common, "connect", return_value=_connect_ok(dev)),
             patch.object(
-                cli.common, "load_commands",
-                return_value=["show version"],
+                cli.common,
+                "load_commands",
+                return_value=["show a", "show b"],
             ),
         ):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-        # load_commands がフィルタ済みの1コマンドだけ返すので cli() は1回
-        mock_dev.cli.assert_called_once_with("show version")
-
-    def test_showfile_exception_on_one_command(
-        self, junos_common, mock_args, mock_config
-    ):
-        """途中のコマンドで例外 → エラー返却"""
-        mock_args.showfile = "commands.txt"
-        mock_args.show_command = None
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = Exception("RPC timeout")
-
-        with (
-            patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}),
-            patch.object(
-                cli.common, "load_commands",
-                return_value=["show version", "show bgp summary"],
-            ),
-        ):
-            result = cli.cmd_show("test-host")
-
-        assert result == 1
-        mock_dev.close.assert_called_once()
-
-    def test_showfile_connect_fail(self, junos_common, mock_args, mock_config):
-        """接続失敗時に 1 を返す"""
-        mock_args.showfile = "commands.txt"
-        mock_args.show_command = None
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": False, "dev": None, "error": "ConnectError", "error_message": "mock connect error"}):
-            result = cli.cmd_show("test-host")
-            assert result == 1
+            rc = cli.cmd_show("test-host")
+        assert rc == 1
+        # Second command not attempted.
+        assert dev.cli.call_count == 1
+        dev.close.assert_called_once()
 
 
 class TestLoadCommands:
-    """common.load_commands() ヘルパーの単体テスト"""
+    """common.load_commands strips blank / comment lines."""
 
-    def test_load_commands(self, tmp_path):
-        """コメント行と空行を除外してコマンド行のみ返す"""
-        cmd_file = tmp_path / "commands.txt"
-        cmd_file.write_text(
-            "# コメント行\n"
+    def test_filters_comments_and_blanks(self, tmp_path):
+        f = tmp_path / "commands.txt"
+        f.write_text(
+            "# comment\n"
             "show version\n"
             "\n"
-            "  # インデント付きコメント\n"
+            "  # indented comment\n"
             "show interfaces terse\n"
             "  show route summary  \n"
         )
-        result = common.load_commands(str(cmd_file))
-        assert result == [
+        assert common.load_commands(str(f)) == [
             "show version",
             "show interfaces terse",
             "show route summary",
         ]
 
-    def test_load_commands_empty_file(self, tmp_path):
-        """空ファイルからは空リストが返る"""
-        cmd_file = tmp_path / "empty.txt"
-        cmd_file.write_text("")
-        result = common.load_commands(str(cmd_file))
-        assert result == []
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        assert common.load_commands(str(f)) == []
 
-    def test_load_commands_only_comments(self, tmp_path):
-        """コメントのみのファイルからは空リストが返る"""
-        cmd_file = tmp_path / "comments.txt"
-        cmd_file.write_text("# comment 1\n# comment 2\n\n")
-        result = common.load_commands(str(cmd_file))
-        assert result == []
-
-
-class TestCliWithRetry:
-    """_cli_with_retry() のテスト (Issue #38)"""
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_retry_success_after_timeout(self, mock_sleep, junos_common, mock_args):
-        """1回目 RpcTimeoutError → 2回目成功"""
-        mock_args.retry = 2
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = [RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30), "output"]
-        result = cli._cli_with_retry(mock_dev, "show version", "test-host", 2)
-        assert result == "output"
-        assert mock_dev.cli.call_count == 2
-        mock_sleep.assert_called_once_with(5)
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_retry_exhausted(self, mock_sleep, junos_common, mock_args):
-        """リトライ回数を使い切ったら RpcTimeoutError を再送出"""
-        import pytest
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30)
-        with pytest.raises(RpcTimeoutError):
-            cli._cli_with_retry(mock_dev, "show version", "test-host", 2)
-        assert mock_dev.cli.call_count == 3  # 初回 + リトライ2回
-        assert mock_sleep.call_count == 2
-        mock_sleep.assert_has_calls([call(5), call(10)])
-
-    def test_no_retry(self, junos_common, mock_args):
-        """retry=0 で RpcTimeoutError はそのまま送出"""
-        import pytest
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30)
-        with pytest.raises(RpcTimeoutError):
-            cli._cli_with_retry(mock_dev, "show version", "test-host", 0)
-        assert mock_dev.cli.call_count == 1
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_non_timeout_not_retried(self, mock_sleep, junos_common, mock_args):
-        """RpcTimeoutError 以外の例外はリトライしない"""
-        import pytest
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = RuntimeError("other error")
-        with pytest.raises(RuntimeError):
-            cli._cli_with_retry(mock_dev, "show version", "test-host", 2)
-        assert mock_dev.cli.call_count == 1
-        mock_sleep.assert_not_called()
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_backoff_increases(self, mock_sleep, junos_common, mock_args):
-        """バックオフが 5, 10, 15... と増加する"""
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = [
-            RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30),
-            RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30),
-            "output",
-        ]
-        result = cli._cli_with_retry(mock_dev, "show version", "test-host", 3)
-        assert result == "output"
-        mock_sleep.assert_has_calls([call(5), call(10)])
-
-
-class TestCmdShowRetry:
-    """cmd_show() のリトライ統合テスト (Issue #38)"""
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_show_retry_success(self, mock_sleep, junos_common, mock_args,
-                                 mock_config, capsys):
-        """cmd_show で RpcTimeoutError 後にリトライ成功"""
-        mock_args.show_command = "show system alarms"
-        mock_args.retry = 1
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = [
-            RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30),
-            "No alarms currently active",
-        ]
-
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-        assert mock_dev.cli.call_count == 2
-        captured = capsys.readouterr()
-        assert "No alarms currently active" in captured.out
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_show_retry_exhausted_returns_error(self, mock_sleep, junos_common,
-                                                 mock_args, mock_config):
-        """リトライ使い切りで exit code 1"""
-        mock_args.show_command = "show system alarms"
-        mock_args.retry = 1
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30)
-
-        with patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
-            result = cli.cmd_show("test-host")
-
-        assert result == 1
-        assert mock_dev.cli.call_count == 2
-        mock_dev.close.assert_called_once()
-
-    @patch("junos_ops.cli.time.sleep")
-    def test_showfile_retry(self, mock_sleep, junos_common, mock_args,
-                             mock_config, capsys):
-        """-f モードでもリトライが効く"""
-        mock_args.showfile = "commands.txt"
-        mock_args.show_command = None
-        mock_args.retry = 1
-        mock_dev = MagicMock()
-        mock_dev.cli.side_effect = [
-            RpcTimeoutError(MagicMock(hostname="test-host"), "command", 30),
-            "terse output",
-            "route summary",
-        ]
-
-        with (
-            patch.object(cli.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}),
-            patch.object(
-                cli.common, "load_commands",
-                return_value=["show interfaces terse", "show route summary"],
-            ),
-        ):
-            result = cli.cmd_show("test-host")
-
-        assert result == 0
-        assert mock_dev.cli.call_count == 3
-        captured = capsys.readouterr()
-        assert "terse output" in captured.out
-        assert "route summary" in captured.out
+    def test_comments_only(self, tmp_path):
+        f = tmp_path / "c.txt"
+        f.write_text("# a\n# b\n\n")
+        assert common.load_commands(str(f)) == []


### PR DESCRIPTION
## Summary
Partial close of #44. Adds structured output to the `show` subcommand and sets up the display-layer migration for it.

- New `junos_ops/show.py` core module (`run_cli`, `run_cli_batch`, `_cli_with_retry`, `VALID_FORMATS`) returning dicts
- `display.format_show` / `print_show` implemented — was a `NotImplementedError` stub
- `show` subcommand: new `-F` / `--format {text,json,xml}` flag
  - `text` (default): `dev.cli(cmd)` — unchanged legacy behaviour
  - `json`: `dev.cli(cmd, format=\"json\")` → pretty-printed JSON via `json.dumps(indent=2, ensure_ascii=False)`
  - `xml`: `dev.cli(cmd, format=\"xml\")` → pretty-printed XML via `etree.tostring(pretty_print=True)`
- `run_cli_batch` (i.e. `show -f FILE`) short-circuits on first failure, matching previous behaviour
- README (en/ja) document the flag and the NETCONF caveat: `| match` / `| last` / `| count` are dropped under `json` / `xml` (Juniper/junos-mcp-server#4, #12) but honoured for `text`

## Out of scope (phase 2)
- `common.run_rpc(dev, rpc_name, **kw) -> dict` helper with jxmlease/lxml shim
- `jxmlease` as an optional extra
- junos-mcp side integration (separate repo)

## Test plan
- [x] `pytest tests/test_show.py` — 25 passed (text/json/xml passthrough, retry, short-circuit batch, format rendering)
- [x] Full `pytest tests/` — 268 passed, no regressions
- [x] `python -m junos_ops show --help` renders `-F, --format {text,json,xml}`
- [ ] Real-device smoke test (`--format json` on a live host, verify structured payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)