### PR TITLE
fix: bump RSI timeout to 2400s for SRX_BRANCH and EX2300-24T

### DIFF
--- a/junos_ops/rsi.py
+++ b/junos_ops/rsi.py
@@ -30,9 +30,9 @@ def get_support_information(dev) -> dict:
     # model-specific timeout selection
     try:
         if dev.facts["personality"] == "SRX_BRANCH":
-            timeout = 1200  # SRX3xx is slow
+            timeout = 2400  # SRX300/320/340/345 are very slow; 1200 was borderline
         elif dev.facts["model"] == "EX2300-24T":
-            timeout = 1200
+            timeout = 2400
         elif len(dev.facts["model_info"]) >= 2:
             # Virtual Chassis is slower
             timeout = 1800

--- a/junos_ops/rsi.py
+++ b/junos_ops/rsi.py
@@ -32,12 +32,12 @@ def get_support_information(dev) -> dict:
         if dev.facts["personality"] == "SRX_BRANCH":
             timeout = 2400  # SRX300/320/340/345 are very slow; 1200 was borderline
         elif dev.facts["model"] == "EX2300-24T":
-            timeout = 2400
+            timeout = 2400  # low-flash EX2300 RSI can exceed 1200s under load
         elif len(dev.facts["model_info"]) >= 2:
             # Virtual Chassis is slower
             timeout = 1800
             if dev.facts["model"] == "QFX5110-48S-4C":
-                timeout = 2400  # QFX5110-48S-4C is slowest
+                timeout = 2400  # matches the slowest tier (SRX_BRANCH / EX2300-24T)
         else:
             timeout = 600
     except Exception as e:

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -25,7 +25,7 @@ class TestGetSupportInformation:
         )
 
     def test_srx_branch_timeout(self):
-        """SRX_BRANCH は timeout=1200"""
+        """SRX_BRANCH は timeout=2400"""
         dev = MagicMock()
         dev.facts = {
             "personality": "SRX_BRANCH",
@@ -36,11 +36,11 @@ class TestGetSupportInformation:
         }
         rsi.get_support_information(dev)
         dev.rpc.get_support_information.assert_called_once_with(
-            {"format": "text"}, dev_timeout=1200
+            {"format": "text"}, dev_timeout=2400
         )
 
     def test_ex2300_timeout(self):
-        """EX2300-24T は timeout=1200"""
+        """EX2300-24T は timeout=2400"""
         dev = MagicMock()
         dev.facts = {
             "personality": "SWITCH",
@@ -51,7 +51,7 @@ class TestGetSupportInformation:
         }
         rsi.get_support_information(dev)
         dev.rpc.get_support_information.assert_called_once_with(
-            {"format": "text"}, dev_timeout=1200
+            {"format": "text"}, dev_timeout=2400
         )
 
     def test_virtual_chassis_timeout(self):


### PR DESCRIPTION
## Summary

- SRX_BRANCH (SRX300/320/340/345) and EX2300-24T: 1200s → 2400s
- No behavior change for other platforms

## Why

A production deployment (84 JUNOS devices, nightly nuwan-configuration run) showed 11+ SRX_BRANCH devices consistently hitting `RpcTimeoutError` at 1200s during `get-support-information`, while their SCF collection succeeded. One device finished SCF but its RSI RPC crossed 1200s.

SRX_BRANCH routers running heavy filter/NAT configs can spend 15–25 minutes gathering support information over a netconf-ssh session, especially via SSH ProxyCommand. 1200s was borderline; doubling to 2400s gives real-world headroom and matches the existing `QFX5110-48S-4C` upper bound.

## Test plan

- [x] py_compile passes
- [ ] Manual `junos-ops rsi` against an SRX300 via ProxyCommand finishes within 2400s
- [ ] Nightly config collection no longer emits `RpcTimeoutError` spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)