### PR TITLE
chore: ignore local scratch files at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ logger.log*
 
 # JUNOSパッケージ
 *.tgz
+
+# ローカル scratch（`git add -A` 事故防止、v0.16.2 yank 教訓）
+.srx-nat-usage.ini
+junos-rsi.py
+safe_copy.py
+sw.py
+test_safe_copy.py
+thread.py
+ver.py


### PR DESCRIPTION
## Summary

- Add seven scratch files to `.gitignore` so they are never accidentally staged.
- Files are preserved locally (not deleted); the change is purely meta/ops.

## Why

These files have been sitting at the repo root across multiple sessions. The v0.16.2 yank incident was triggered by \`git add -A\` picking up a similar set of untracked files. Listing them explicitly in \`.gitignore\` eliminates that failure mode.

## Test plan

- [x] \`git status\` no longer lists them as untracked.
- [x] Files remain on disk.