### PR TITLE
fix(reboot): use pending-slot install time for re-install skip decision

### DIFF
--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1406,7 +1406,10 @@ def check_and_reinstall(hostname, dev) -> dict:
           needed.
         - ``skip_reason`` (str | None): ``"no_pending"`` |
           ``"no_commit_info"`` | ``"config_unchanged"`` | ``"dry_run"``
-          | None.
+          | ``"already_pending"`` | None. ``"already_pending"`` is set
+          when JUNOS rejects the re-install because the target firmware
+          is already staged in the pending slot (issue #54) — the caller
+          should proceed to schedule the reboot unchanged.
         - ``dry_run`` (bool)
         - ``commit`` (dict | None): ``{epoch, datetime, user, client}``
           of the most recent commit, when available.
@@ -1537,14 +1540,34 @@ def check_and_reinstall(hostname, dev) -> dict:
             del sw
         logger.debug(f"check_and_reinstall: {msg=}")
         result["install_message"] = msg
-        result["reinstalled"] = True
         if status:
+            result["reinstalled"] = True
             steps.append({
                 "action": "reinstall",
                 "ok": True,
                 "message": "\tre-install: successful",
             })
+        elif "already an install pending" in (msg or "").lower():
+            # JUNOS refuses to re-validate/re-install when the target image is
+            # already staged in the pending slot (e.g. from a prior
+            # ``junos-ops upgrade`` run). In that case the pending firmware
+            # already reflects the running config for validation purposes and
+            # the only remaining step is ``request system reboot`` — which is
+            # what the caller is about to do. Treat this as a skip, not a
+            # failure, so ``reboot`` can proceed. See issue #54.
+            result["skipped"] = True
+            result["skip_reason"] = "already_pending"
+            steps.append({
+                "action": "reinstall",
+                "ok": True,
+                "skipped": True,
+                "message": (
+                    "\tre-install: skipped "
+                    "(firmware already pending; reboot will complete the install)"
+                ),
+            })
         else:
+            result["reinstalled"] = True
             result["ok"] = False
             result["error"] = "reinstall_failed"
             steps.append({

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1266,6 +1266,51 @@ def get_commit_information(dev):
     return None
 
 
+def get_pending_install_time(dev):
+    """Best-effort epoch seconds when the pending firmware slot was staged.
+
+    Returns the mtime of the newest file under ``/var/sw/pkg/``, which is
+    where the JUNOS installer saves the staged package on every platform
+    observed so far (EX / QFX / SRX / MX). The embedded config in the
+    pending image was captured at this time, so comparing it against the
+    latest commit epoch answers the real question that
+    :func:`check_and_reinstall` is trying to answer: "does the pending
+    image already reflect the running config, or is a re-install needed
+    to update the embedded config?"
+
+    :returns: epoch seconds (int), or ``None`` if the directory is empty,
+        missing, or the RPC fails. Callers should treat ``None`` as
+        "unknown" and fall back to secondary heuristics.
+    """
+    try:
+        xml = dev.rpc.file_list(path="/var/sw/pkg/", detail=True)
+    except RpcError as e:
+        logger.debug(f"get_pending_install_time: RpcError: {e}")
+        return None
+    except RpcTimeoutError as e:
+        logger.debug(f"get_pending_install_time: RpcTimeoutError: {e}")
+        return None
+    except Exception as e:
+        logger.debug(f"get_pending_install_time: {e}")
+        return None
+
+    newest = 0
+    for fi in xml.iter("file-information"):
+        fd = fi.find("file-date")
+        if fd is None:
+            continue
+        seconds = fd.get("seconds")
+        if not seconds:
+            continue
+        try:
+            n = int(seconds)
+        except ValueError:
+            continue
+        if n > newest:
+            newest = n
+    return newest if newest > 0 else None
+
+
 def get_rescue_config_time(dev):
     """Get rescue config file modification time.
 
@@ -1405,15 +1450,25 @@ def check_and_reinstall(hostname, dev) -> dict:
         - ``skipped`` (bool): True when we decided no re-install was
           needed.
         - ``skip_reason`` (str | None): ``"no_pending"`` |
-          ``"no_commit_info"`` | ``"config_unchanged"`` | ``"dry_run"``
-          | ``"already_pending"`` | None. ``"already_pending"`` is set
-          when JUNOS rejects the re-install because the target firmware
-          is already staged in the pending slot (issue #54) — the caller
-          should proceed to schedule the reboot unchanged.
+          ``"no_commit_info"`` | ``"pending_current"`` |
+          ``"config_unchanged"`` | ``"dry_run"`` |
+          ``"already_pending"`` | None. ``"pending_current"`` means the
+          pending image's embedded config already reflects the latest
+          commit (primary check, based on pending-slot mtime).
+          ``"config_unchanged"`` is the legacy fallback used when the
+          pending install time cannot be determined; it compares
+          ``commit_epoch`` against ``rescue_epoch`` instead.
+          ``"already_pending"`` is a safety net set when JUNOS refuses a
+          re-install because the target firmware is already staged —
+          see issue #54. When a drift is detected (commit newer than
+          pending install) the step list includes a warning.
         - ``dry_run`` (bool)
         - ``commit`` (dict | None): ``{epoch, datetime, user, client}``
           of the most recent commit, when available.
         - ``rescue_epoch`` (int | None): mtime of the rescue config.
+        - ``pending_install_epoch`` (int | None): best-effort epoch of
+          the most recent file under ``/var/sw/pkg/``, used as a proxy
+          for when the pending firmware was staged.
         - ``rescue_save`` (dict | None): ``{ok, message, error}``.
         - ``install_message`` (str | None): PyEZ ``SW.install`` message.
         - ``steps`` (list[dict]): chronological progress for display.
@@ -1431,6 +1486,7 @@ def check_and_reinstall(hostname, dev) -> dict:
         "dry_run": common.args.dry_run,
         "commit": None,
         "rescue_epoch": None,
+        "pending_install_epoch": None,
         "rescue_save": None,
         "install_message": None,
         "steps": steps,
@@ -1460,18 +1516,44 @@ def check_and_reinstall(hostname, dev) -> dict:
     }
     rescue_epoch = get_rescue_config_time(dev)
     result["rescue_epoch"] = rescue_epoch
+    pending_install_epoch = get_pending_install_time(dev)
+    result["pending_install_epoch"] = pending_install_epoch
 
-    if rescue_epoch is not None and commit_epoch <= rescue_epoch:
-        logger.debug("check_and_reinstall: config not modified after rescue save, skip")
+    # The pending firmware image carries the config that was active at
+    # install time. If the latest commit is no newer than that snapshot,
+    # the pending image already reflects the running config and no
+    # re-install is needed. This is the primary and authoritative check.
+    #
+    # Fall back to the legacy rescue-save comparison when
+    # ``pending_install_epoch`` cannot be determined (older platforms or
+    # RPC failure); the rescue save in install() is usually close in time
+    # to the pending install, so it remains a reasonable secondary proxy.
+    skip_epoch = None
+    if pending_install_epoch is not None:
+        skip_epoch = pending_install_epoch
+    elif rescue_epoch is not None:
+        skip_epoch = rescue_epoch
+
+    if skip_epoch is not None and commit_epoch <= skip_epoch:
+        logger.debug(
+            "check_and_reinstall: pending image already covers latest commit, skip"
+        )
         result["skipped"] = True
-        result["skip_reason"] = "config_unchanged"
+        result["skip_reason"] = (
+            "pending_current" if pending_install_epoch is not None
+            else "config_unchanged"
+        )
         return result
 
-    # Config modified after rescue save (or no rescue config exists).
-    if rescue_epoch is None:
+    # Config was modified after the pending image was staged — the pending
+    # image's embedded config is stale. Warn and attempt re-install so the
+    # pending slot picks up the current config. If JUNOS refuses because
+    # an install is already pending (issue #54), we fall through to the
+    # safety net below that records a skip with a drift warning.
+    if pending_install_epoch is None and rescue_epoch is None:
         steps.append({
             "action": "warning",
-            "message": "\tWARNING: rescue config not found. "
+            "message": "\tWARNING: cannot determine pending install time. "
                        "Re-installing firmware with current config.",
         })
     else:
@@ -1548,13 +1630,16 @@ def check_and_reinstall(hostname, dev) -> dict:
                 "message": "\tre-install: successful",
             })
         elif "already an install pending" in (msg or "").lower():
-            # JUNOS refuses to re-validate/re-install when the target image is
-            # already staged in the pending slot (e.g. from a prior
-            # ``junos-ops upgrade`` run). In that case the pending firmware
-            # already reflects the running config for validation purposes and
-            # the only remaining step is ``request system reboot`` — which is
-            # what the caller is about to do. Treat this as a skip, not a
-            # failure, so ``reboot`` can proceed. See issue #54.
+            # Safety net: JUNOS refuses to re-install on top of an existing
+            # pending slot. We get here when the primary timestamp check
+            # above decided a re-install was needed (commit is newer than
+            # ``pending_install_epoch`` / ``rescue_epoch``) but the only
+            # way to actually restage the pending image is to rollback
+            # first, which is disruptive enough that we do not do it
+            # automatically. Record a drift warning and let ``reboot``
+            # proceed — the operator should know that the pending image
+            # carries the config from ``pending_install_epoch``, not the
+            # latest commit. See issue #54.
             result["skipped"] = True
             result["skip_reason"] = "already_pending"
             steps.append({
@@ -1566,6 +1651,15 @@ def check_and_reinstall(hostname, dev) -> dict:
                     "(firmware already pending; reboot will complete the install)"
                 ),
             })
+            if pending_install_epoch is not None and commit_epoch > pending_install_epoch:
+                steps.append({
+                    "action": "warning",
+                    "message": (
+                        "\tWARNING: latest commit is newer than the pending image; "
+                        "reboot will activate firmware with stale embedded config. "
+                        "Roll back the pending slot and re-run upgrade to refresh it."
+                    ),
+                })
         else:
             result["reinstalled"] = True
             result["ok"] = False

--- a/tests/test_reboot.py
+++ b/tests/test_reboot.py
@@ -96,8 +96,47 @@ class TestCheckAndReinstall:
                             result = junos_upgrade.check_and_reinstall("test-host", dev)
         assert result["ok"] is False
 
+    def test_pending_current_primary_skip(self, junos_upgrade, mock_args, mock_config):
+        """pending_install_epoch >= commit_epoch → primary skip (issue #54 fundamental fix)"""
+        dev = MagicMock()
+        with patch.object(junos_upgrade, "get_pending_version", return_value="23.4R2-S7.4"):
+            with patch.object(junos_upgrade, "get_commit_information", return_value=(1000, "2001-01-01", "admin", "cli")):
+                with patch.object(junos_upgrade, "get_rescue_config_time", return_value=None):
+                    with patch.object(junos_upgrade, "get_pending_install_time", return_value=2000):
+                        result = junos_upgrade.check_and_reinstall("test-host", dev)
+        assert result["ok"] is True
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "pending_current"
+        assert result["reinstalled"] is False
+        # rescue save 不要（SW.install も呼ばれていないはず）
+        assert result["rescue_save"] is None
+
+    def test_pending_current_takes_priority_over_rescue(self, junos_upgrade, mock_args, mock_config):
+        """pending_install_epoch が利用できれば rescue_epoch より優先"""
+        dev = MagicMock()
+        # commit(1500) > rescue(1000) だが pending_install(2000) はより新しい → skip
+        with patch.object(junos_upgrade, "get_pending_version", return_value="23.4R2-S7.4"):
+            with patch.object(junos_upgrade, "get_commit_information", return_value=(1500, "2001-01-01", "admin", "cli")):
+                with patch.object(junos_upgrade, "get_rescue_config_time", return_value=1000):
+                    with patch.object(junos_upgrade, "get_pending_install_time", return_value=2000):
+                        result = junos_upgrade.check_and_reinstall("test-host", dev)
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "pending_current"
+
+    def test_rescue_fallback_when_pending_unknown(self, junos_upgrade, mock_args, mock_config):
+        """get_pending_install_time が None → rescue_epoch に fallback"""
+        dev = MagicMock()
+        with patch.object(junos_upgrade, "get_pending_version", return_value="22.4R3-S6.5"):
+            with patch.object(junos_upgrade, "get_commit_information", return_value=(1000, "2001-01-01", "admin", "cli")):
+                with patch.object(junos_upgrade, "get_rescue_config_time", return_value=2000):
+                    with patch.object(junos_upgrade, "get_pending_install_time", return_value=None):
+                        result = junos_upgrade.check_and_reinstall("test-host", dev)
+        assert result["skipped"] is True
+        # fallback path は legacy の reason を保持
+        assert result["skip_reason"] == "config_unchanged"
+
     def test_already_pending_treated_as_skip(self, junos_upgrade, mock_args, mock_config):
-        """`already an install pending` は再インストール不要の skip として扱う (issue #54)"""
+        """`already an install pending` は再インストール不要の skip として扱う (issue #54 安全網)"""
         dev = MagicMock()
         dev.facts = {"model": "EX2300-24T"}
         mock_sw = MagicMock()
@@ -113,9 +152,10 @@ class TestCheckAndReinstall:
         with patch.object(junos_upgrade, "get_pending_version", return_value="22.4R3-S6.5"):
             with patch.object(junos_upgrade, "get_commit_information", return_value=(2000, "2001-01-01", "admin", "cli")):
                 with patch.object(junos_upgrade, "get_rescue_config_time", return_value=None):
-                    with patch("junos_ops.upgrade.Config", return_value=mock_cu):
-                        with patch("junos_ops.upgrade.SW", return_value=mock_sw):
-                            result = junos_upgrade.check_and_reinstall("test-host", dev)
+                    with patch.object(junos_upgrade, "get_pending_install_time", return_value=None):
+                        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+                            with patch("junos_ops.upgrade.SW", return_value=mock_sw):
+                                result = junos_upgrade.check_and_reinstall("test-host", dev)
         # reboot should still be allowed to proceed.
         assert result["ok"] is True
         assert result["skipped"] is True
@@ -124,6 +164,32 @@ class TestCheckAndReinstall:
         assert result["error"] is None
         assert any(
             "already pending" in step.get("message", "") for step in result["steps"]
+        )
+
+    def test_drift_warning_when_commit_newer_than_pending(self, junos_upgrade, mock_args, mock_config):
+        """commit > pending_install の状態で already_pending → config drift 警告付き skip"""
+        dev = MagicMock()
+        dev.facts = {"model": "EX2300-24T"}
+        mock_sw = MagicMock()
+        mock_sw.install.return_value = (
+            False,
+            "Package validation failed\nERROR: There is already an install pending.\n",
+        )
+        mock_cu = MagicMock()
+        mock_cu.rescue.return_value = True
+        with patch.object(junos_upgrade, "get_pending_version", return_value="22.4R3-S6.5"):
+            with patch.object(junos_upgrade, "get_commit_information", return_value=(3000, "2001-01-01", "admin", "cli")):
+                with patch.object(junos_upgrade, "get_rescue_config_time", return_value=None):
+                    with patch.object(junos_upgrade, "get_pending_install_time", return_value=1000):
+                        with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+                            with patch("junos_ops.upgrade.SW", return_value=mock_sw):
+                                result = junos_upgrade.check_and_reinstall("test-host", dev)
+        assert result["ok"] is True
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "already_pending"
+        # drift 警告が含まれる
+        assert any(
+            "stale embedded config" in step.get("message", "") for step in result["steps"]
         )
 
     def test_rescue_save_failure(self, junos_upgrade, mock_args, mock_config):

--- a/tests/test_reboot.py
+++ b/tests/test_reboot.py
@@ -96,6 +96,36 @@ class TestCheckAndReinstall:
                             result = junos_upgrade.check_and_reinstall("test-host", dev)
         assert result["ok"] is False
 
+    def test_already_pending_treated_as_skip(self, junos_upgrade, mock_args, mock_config):
+        """`already an install pending` は再インストール不要の skip として扱う (issue #54)"""
+        dev = MagicMock()
+        dev.facts = {"model": "EX2300-24T"}
+        mock_sw = MagicMock()
+        mock_sw.install.return_value = (
+            False,
+            "Package validation failed\n"
+            "ERROR: There is already an install pending.\n"
+            "ERROR:     Use the 'request system reboot' command to complete the install,\n"
+            "ERROR:     or the 'request system software rollback' command to back it out.\n",
+        )
+        mock_cu = MagicMock()
+        mock_cu.rescue.return_value = True
+        with patch.object(junos_upgrade, "get_pending_version", return_value="22.4R3-S6.5"):
+            with patch.object(junos_upgrade, "get_commit_information", return_value=(2000, "2001-01-01", "admin", "cli")):
+                with patch.object(junos_upgrade, "get_rescue_config_time", return_value=None):
+                    with patch("junos_ops.upgrade.Config", return_value=mock_cu):
+                        with patch("junos_ops.upgrade.SW", return_value=mock_sw):
+                            result = junos_upgrade.check_and_reinstall("test-host", dev)
+        # reboot should still be allowed to proceed.
+        assert result["ok"] is True
+        assert result["skipped"] is True
+        assert result["skip_reason"] == "already_pending"
+        assert result["reinstalled"] is False
+        assert result["error"] is None
+        assert any(
+            "already pending" in step.get("message", "") for step in result["steps"]
+        )
+
     def test_rescue_save_failure(self, junos_upgrade, mock_args, mock_config):
         """rescue config 保存失敗 → True を返す"""
         dev = MagicMock()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -199,6 +199,61 @@ class TestGetRescueConfigTime:
         assert result is None
 
 
+class TestGetPendingInstallTime:
+    """get_pending_install_time() のテスト (issue #54 根本対策)"""
+
+    def _make_dir_listing(self, entries):
+        """複数 file-information を持つ directory XML を作る。entries: list of (name, seconds)。"""
+        root = etree.Element("directory")
+        for name, seconds in entries:
+            fi = etree.SubElement(root, "file-information")
+            etree.SubElement(fi, "file-name").text = name
+            fd = etree.SubElement(fi, "file-date")
+            fd.set("seconds", seconds)
+            fd.text = "Apr 16 12:00"
+        return root
+
+    def test_single_file(self, junos_upgrade, mock_args):
+        """1ファイルだけの時はその mtime を返す"""
+        dev = MagicMock()
+        dev.rpc.file_list.return_value = self._make_dir_listing(
+            [("junos-arm-32-23.4R2-S7.4.tgz", "1713200000")]
+        )
+        assert junos_upgrade.get_pending_install_time(dev) == 1713200000
+
+    def test_picks_newest(self, junos_upgrade, mock_args):
+        """複数ファイルがあれば最新の mtime を返す"""
+        dev = MagicMock()
+        dev.rpc.file_list.return_value = self._make_dir_listing([
+            ("junos-old.tgz", "1000000000"),
+            ("junos-new.tgz", "1713200000"),
+            ("junos-mid.tgz", "1500000000"),
+        ])
+        assert junos_upgrade.get_pending_install_time(dev) == 1713200000
+
+    def test_empty_directory(self, junos_upgrade, mock_args):
+        """ファイルなし → None"""
+        dev = MagicMock()
+        dev.rpc.file_list.return_value = etree.Element("directory")
+        assert junos_upgrade.get_pending_install_time(dev) is None
+
+    def test_rpc_error(self, junos_upgrade, mock_args):
+        """RPC エラー → None"""
+        from jnpr.junos.exception import RpcError
+        dev = MagicMock()
+        dev.rpc.file_list.side_effect = RpcError()
+        assert junos_upgrade.get_pending_install_time(dev) is None
+
+    def test_non_integer_seconds(self, junos_upgrade, mock_args):
+        """seconds が int に parse できないエントリは無視"""
+        dev = MagicMock()
+        dev.rpc.file_list.return_value = self._make_dir_listing([
+            ("bogus.tgz", "notanumber"),
+            ("good.tgz", "1713200000"),
+        ])
+        assert junos_upgrade.get_pending_install_time(dev) == 1713200000
+
+
 class TestShowVersionWithoutFile:
     """show_version() が .file 未定義でもエラーにならないテスト (Issue #37)"""
 


### PR DESCRIPTION
## Summary

Rework `check_and_reinstall` to base its skip decision on the **pending-slot install time**, not on the rescue-config mtime proxy. This closes issue #54 at the root rather than just handling the JUNOS error message.

## Why

`check_and_reinstall` existed to ensure the pending firmware image's embedded config reflects the current running config before reboot. Historically it used `commit_epoch <= rescue_epoch` as a skip condition, but `rescue_epoch` only coincidentally tracks the pending install time (because `install()` runs a rescue save next to pkgadd). When that correlation breaks — rescue config was never saved, or was saved long before the pending install — the proxy reports "re-install needed" when in fact the pending image already reflects the latest commit. JUNOS then refuses the redundant re-install with `There is already an install pending.`

## How

Three layered checks, from cheapest to most defensive:

1. **Primary (new):** `get_pending_install_time(dev)` reads the newest mtime under `/var/sw/pkg/` and compares it against `commit_epoch`. If `commit_epoch <= pending_install_epoch`, the pending image already carries the current config — skip immediately (`skip_reason="pending_current"`). No rescue save, no install RPC.
2. **Secondary (legacy):** if `pending_install_epoch` cannot be determined (older platforms, RPC failure), fall back to `commit_epoch <= rescue_epoch` with `skip_reason="config_unchanged"`. This preserves the old behaviour on platforms where the primary check can't run.
3. **Safety net (previous commit, kept):** if both checks say re-install and JUNOS still refuses with `already an install pending`, record `skip_reason="already_pending"`. When the drift is provable (`commit_epoch > pending_install_epoch`), emit a `stale embedded config` warning so the operator knows the reboot will activate firmware with the older config.

## Test plan

- [x] `get_pending_install_time`: 5 new tests (single file, newest-of-many, empty dir, RPC error, malformed seconds).
- [x] `check_and_reinstall`: 4 new tests (primary skip, primary priority over rescue, rescue fallback when pending unknown, drift warning path).
- [x] Full suite: 278 passed (+9 new).
- [ ] Manual retry against an affected SRX300 — verify primary skip fires and reboot proceeds without rescue save / install attempt.

Closes #54.