### PR TITLE
fix(reboot): handle XMLSyntaxError on get_reboot_information gracefully

### DIFF
--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1632,16 +1632,66 @@ def reboot(hostname: str, dev, reboot_dt: datetime.datetime) -> dict:
         "error": None,
     }
 
+    xml_str: str = ""
+    parse_error: Exception | None = None
     try:
         rpc = dev.rpc.get_reboot_information({"format": "text"})
+        xml_str = etree.tostring(rpc, encoding="unicode")
     except ConnectError as err:
         logger.error(f"{err=}")
         result["code"] = 2
         result["error"] = "ConnectError"
         return result
-    xml_str = etree.tostring(rpc, encoding="unicode")
+    except etree.XMLSyntaxError as e:
+        # PyEZ / lxml can fail to parse the ``get_reboot_information``
+        # response on some devices that already have a halt schedule with
+        # a custom message — observed on SRX345 running 22.4R3-S6.5 when
+        # ``request system halt at "..." message "..."`` had been issued
+        # earlier. The payload is downstream of NETCONF so we never see
+        # the raw bytes here. Record the failure, surface a clear warning,
+        # and fall back to the ``--force`` branch: the separate
+        # ``clear_reboot`` RPC uses a different code path and works fine
+        # against the same device. See issue #60.
+        parse_error = e
+
     logger.debug(f"{xml_str=}")
-    if xml_str.find("No shutdown/reboot scheduled.") < 0:
+    if parse_error is not None:
+        logger.warning(
+            f"{hostname}: get_reboot_information XML parse failed: {parse_error}"
+        )
+        steps.append({
+            "action": "existing_schedule",
+            "message": (
+                "\tWARNING: cannot parse existing reboot schedule "
+                f"({type(parse_error).__name__}: {parse_error}). "
+                "Assume a schedule exists."
+            ),
+        })
+        if not common.args.force:
+            result["code"] = 3
+            result["error"] = "get_reboot_information_parse_error"
+            result["message"] = (
+                "cannot parse existing reboot schedule; retry with --force "
+                "to unconditionally clear the existing schedule before "
+                "proceeding"
+            )
+            steps.append({
+                "action": "error",
+                "message": f"\t{result['message']}",
+            })
+            return result
+        steps.append({
+            "action": "force_clear",
+            "message": "\tforce: clearing reboot schedule blindly (parse failed)",
+        })
+        clear_result = clear_reboot(dev)
+        steps.append({"action": "clear_reboot", **clear_result})
+        if not clear_result["ok"]:
+            result["code"] = 3
+            result["error"] = "clear_reboot_failed"
+            return result
+        result["cleared_existing"] = True
+    elif xml_str.find("No shutdown/reboot scheduled.") < 0:
         logger.debug("ANY SHUTDWON/REBOOT SCHEDULE EXISTS")
         match = re.search(r"^(\w+) requested by (\w+) at (.*)$", xml_str, re.MULTILINE)
         if match and len(match.groups()) == 3:

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1598,7 +1598,8 @@ def reboot(hostname: str, dev, reboot_dt: datetime.datetime) -> dict:
         - ``code`` (int): legacy exit code (0 = success, 2 = cannot read
           reboot info, 3 = clear_reboot failed, 4 = ConnectError on
           reboot RPC, 5 = RpcError on reboot RPC, 6 =
-          check_and_reinstall failed).
+          check_and_reinstall failed, 7 = get_reboot_information XML
+          parse error without ``--force`` — see issue #60).
         - ``dry_run`` (bool)
         - ``reboot_at`` (str): formatted ``yymmddhhmm`` target time.
         - ``existing_schedule`` (str | None): summary of any
@@ -1656,6 +1657,9 @@ def reboot(hostname: str, dev, reboot_dt: datetime.datetime) -> dict:
 
     logger.debug(f"{xml_str=}")
     if parse_error is not None:
+        # ``logger.warning`` rather than ``logger.error`` because the
+        # condition is recoverable via ``--force``; an ``error`` level
+        # would wrongly suggest a terminal failure.
         logger.warning(
             f"{hostname}: get_reboot_information XML parse failed: {parse_error}"
         )
@@ -1668,7 +1672,7 @@ def reboot(hostname: str, dev, reboot_dt: datetime.datetime) -> dict:
             ),
         })
         if not common.args.force:
-            result["code"] = 3
+            result["code"] = 7
             result["error"] = "get_reboot_information_parse_error"
             result["message"] = (
                 "cannot parse existing reboot schedule; retry with --force "

--- a/tests/test_reboot.py
+++ b/tests/test_reboot.py
@@ -170,6 +170,52 @@ class TestRebootWithReinstall:
         assert result["code"] == 6
         assert result["ok"] is False
 
+    def test_reboot_xml_parse_error_without_force(self, junos_upgrade, mock_args, mock_config):
+        """get_reboot_information の XML parse エラー + --force なし → code=3 で fail (issue #60)"""
+        dev = MagicMock()
+        dev.rpc.get_reboot_information.side_effect = etree.XMLSyntaxError(
+            "Opening and ending tag mismatch: request-reboot-status line 3 and rpc-reply",
+            None, 21, 13,
+        )
+        mock_args.force = False
+        reboot_dt = datetime.datetime(2025, 6, 13, 5, 0)
+        result = junos_upgrade.reboot("test-host", dev, reboot_dt)
+        assert result["code"] == 3
+        assert result["ok"] is False
+        assert result["error"] == "get_reboot_information_parse_error"
+        # --force の案内メッセージが含まれる
+        assert "--force" in (result.get("message") or "")
+        assert any(
+            "cannot parse" in step.get("message", "") for step in result["steps"]
+        )
+
+    def test_reboot_xml_parse_error_with_force(self, junos_upgrade, mock_args, mock_config):
+        """get_reboot_information の XML parse エラー + --force → clear_reboot へ blind fall-through (issue #60)"""
+        dev = MagicMock()
+        dev.rpc.get_reboot_information.side_effect = etree.XMLSyntaxError(
+            "Opening and ending tag mismatch: request-reboot-status line 3 and rpc-reply",
+            None, 21, 13,
+        )
+        # clear_reboot は成功させる
+        dev.rpc.request_reboot_clear.return_value = etree.Element("output")
+        mock_sw = MagicMock()
+        mock_sw.reboot.return_value = "Shutdown at Fri Jun 13 05:00:00 2025. [pid 97978]"
+        mock_args.force = True
+        reboot_dt = datetime.datetime(2025, 6, 13, 5, 0)
+        with patch.object(junos_upgrade, "check_and_reinstall", return_value={"ok": True, "steps": []}):
+            with patch.object(junos_upgrade, "clear_reboot", return_value={"ok": True, "message": "cleared"}) as mock_clear:
+                with patch("junos_ops.upgrade.SW", return_value=mock_sw):
+                    result = junos_upgrade.reboot("test-host", dev, reboot_dt)
+        # blind clear が呼ばれて reboot が成功する
+        mock_clear.assert_called_once_with(dev)
+        assert result["cleared_existing"] is True
+        assert result["code"] == 0
+        assert result["ok"] is True
+        assert any(
+            "clearing reboot schedule blindly" in step.get("message", "")
+            for step in result["steps"]
+        )
+
 
 class TestDeleteSnapshots:
     """delete_snapshots() は dict を返す"""

--- a/tests/test_reboot.py
+++ b/tests/test_reboot.py
@@ -171,7 +171,11 @@ class TestRebootWithReinstall:
         assert result["ok"] is False
 
     def test_reboot_xml_parse_error_without_force(self, junos_upgrade, mock_args, mock_config):
-        """get_reboot_information の XML parse エラー + --force なし → code=3 で fail (issue #60)"""
+        """get_reboot_information の XML parse エラー + --force なし → code=7 で fail (issue #60)
+
+        code=7 を code=3 (clear_reboot_failed) と分離してある点を確認する —
+        CLI exit code だけで両者を区別できるのが期待。
+        """
         dev = MagicMock()
         dev.rpc.get_reboot_information.side_effect = etree.XMLSyntaxError(
             "Opening and ending tag mismatch: request-reboot-status line 3 and rpc-reply",
@@ -180,7 +184,7 @@ class TestRebootWithReinstall:
         mock_args.force = False
         reboot_dt = datetime.datetime(2025, 6, 13, 5, 0)
         result = junos_upgrade.reboot("test-host", dev, reboot_dt)
-        assert result["code"] == 3
+        assert result["code"] == 7
         assert result["ok"] is False
         assert result["error"] == "get_reboot_information_parse_error"
         # --force の案内メッセージが含まれる
@@ -215,6 +219,28 @@ class TestRebootWithReinstall:
             "clearing reboot schedule blindly" in step.get("message", "")
             for step in result["steps"]
         )
+
+    def test_reboot_xml_parse_error_with_force_but_clear_fails(
+        self, junos_upgrade, mock_args, mock_config
+    ):
+        """parse エラー + --force だが blind clear_reboot も失敗 → code=3 (clear_reboot_failed)"""
+        dev = MagicMock()
+        dev.rpc.get_reboot_information.side_effect = etree.XMLSyntaxError(
+            "Opening and ending tag mismatch: request-reboot-status line 3 and rpc-reply",
+            None, 21, 13,
+        )
+        mock_args.force = True
+        reboot_dt = datetime.datetime(2025, 6, 13, 5, 0)
+        with patch.object(
+            junos_upgrade, "clear_reboot",
+            return_value={"ok": False, "message": "clear failed"},
+        ) as mock_clear:
+            result = junos_upgrade.reboot("test-host", dev, reboot_dt)
+        mock_clear.assert_called_once_with(dev)
+        # parse_error path でも従来の clear_reboot_failed は code=3 を維持
+        assert result["code"] == 3
+        assert result["error"] == "clear_reboot_failed"
+        assert result["cleared_existing"] is False
 
 
 class TestDeleteSnapshots:


### PR DESCRIPTION
## Summary

Catch \`lxml.etree.XMLSyntaxError\` around the \`get_reboot_information\` RPC in \`reboot()\` so that the command does not silently die when PyEZ fails to parse the device's response. On \`--force\`, fall through to \`clear_reboot(dev)\` (a separate RPC that works on the affected device) and continue with reboot scheduling. Without \`--force\`, return a clear error that points the operator at \`--force\` as the workaround.

## Why (issue #60)

Observed on SRX345 @ 22.4R3-S6.5 that had an existing halt scheduled:

\`\`\`
2026-04-23 17:18:38,190 [ERROR] <host>: Opening and ending tag mismatch: request-reboot-status line 3 and rpc-reply, line 21, column 13
\`\`\`

The existing \`try/except\` only handled \`ConnectError\`, so the lxml parse error escaped the \`reboot()\` frame entirely. The \`--force\` branch further down the function was never reached, leaving operators with no way to unstick the device short of raw SSH.

## How

1. Wrap the RPC + \`etree.tostring\` call in \`try/except etree.XMLSyntaxError\`.
2. On parse failure, append a warning step so the host-atomic output surfaces the problem.
3. If \`common.args.force\` is True, treat the existing schedule as \"unknown but present\" and call \`clear_reboot(dev)\` unconditionally. The separate RPC has been observed to succeed against the same device.
4. If not forced, set \`result[\"code\"] = 3\` / \`error=\"get_reboot_information_parse_error\"\` and embed \`--force\` in the user-facing message.

Option 2 from the issue (regex fallback on raw NETCONF bytes) is deferred: PyEZ does not surface the raw response to callers when parsing fails, and plumbing that in is out of scope for this fix.

## Test plan

- [x] New: \`test_reboot_xml_parse_error_without_force\` — simulates \`XMLSyntaxError\`, expects code=3, \`error=\"get_reboot_information_parse_error\"\`, and the \`--force\` hint.
- [x] New: \`test_reboot_xml_parse_error_with_force\` — same side-effect but with \`--force\`, expects blind \`clear_reboot\` call and a successful reboot schedule.
- [x] Full suite: 275 passed (+2).
- [ ] Manual: \`junos-ops reboot --at YYMMDDHHMM --force <affected-host>\` on the device reported in #60 — should surface the parse-failure warning, run \`clear_reboot\`, and schedule the new reboot.

Fixes #60.