### PR TITLE
fix(logging): suppress ncclient/paramiko INFO logs even when logging.ini is present

### DIFF
--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -43,11 +43,15 @@ else:
         format='%(asctime)s [%(levelname)s] %(message)s',
         handlers=[logging.StreamHandler(sys.stdout)]
     )
-    # ncclient / paramiko / junos-eznc emit every NETCONF and SSH frame
-    # at INFO. Without an explicit logging.ini, our INFO root would drown
-    # the user in protocol traffic, so raise these to WARNING by default.
-    for noisy in ("ncclient", "paramiko", "jnpr.junos"):
-        logging.getLogger(noisy).setLevel(logging.WARNING)
+# ncclient / paramiko / junos-eznc emit every NETCONF and SSH frame at
+# INFO.  Apply WARNING suppression regardless of whether logging.ini was
+# found: when logging.ini sets root=DEBUG but omits these loggers, they
+# inherit DEBUG and flood the terminal.  Only override loggers that have
+# no explicit level (NOTSET) so a deliberate logging.ini entry is honoured.
+for noisy in ("ncclient", "paramiko", "jnpr.junos"):
+    lgr = logging.getLogger(noisy)
+    if lgr.level == logging.NOTSET:
+        lgr.setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 from junos_ops import __version__ as version  # noqa: E402


### PR DESCRIPTION
## Summary

When `logging.ini` exists and sets `root=DEBUG` (the repo default), ncclient/paramiko/jnpr.junos loggers were not in the noisy-suppression block because it only ran in the `else` (no logging.ini) path. Those loggers inherit root's DEBUG level and emit NETCONF XML frames during `check --connect`/`--remote`.

**Fix**: move the WARNING suppression outside the `if/else`, so it always runs after any logging setup. Only applies to loggers with `level == NOTSET` (not explicitly configured in logging.ini), so deliberate overrides in a custom config are honoured.

## Root cause

```python
# Before: suppression only in the else branch
if _logging_ini:
    logging.config.fileConfig(_logging_ini)   # root=DEBUG, ncclient not listed
else:
    ...
    for noisy in (...):                        # never reached when logging.ini found
        logging.getLogger(noisy).setLevel(WARNING)
```

## Test plan

- [x] `pytest tests/ -v` — 289 tests pass
- [ ] Real device: `junos-ops check --connect --tags main` — no ncclient INFO frames in output

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)