### PR TITLE
fix(ci): opt into Node.js 24 for deb and rpm workflows

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -16,6 +16,8 @@ jobs:
     container: rockylinux:9
     permissions:
       contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

`actions/checkout@v4` と `actions/upload-artifact@v4` が Node.js 20 で動作しており、2026年6月2日以降は強制 Node.js 24 移行・9月16日には Node.js 20 が削除される予定のため対処。

GitHub 推奨の `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を `deb.yml` と `rpm.yml` の両ジョブに追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)