### PR TITLE
fix(ci): bump actions/checkout to v6 and upload-artifact to v7

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
           done
 
       - name: Upload .deb as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junos-ops-${{ matrix.codename }}
           path: junos-ops_*~${{ matrix.codename }}.deb

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
             .
 
       - name: Upload .rpm as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: junos-ops-el9
           path: "${{ github.workspace }}/*.rpm"


### PR DESCRIPTION
## Summary

`deb.yml` と `rpm.yml` の actions バージョンを他のワークフロー（`ci.yml`、`release.yml`）に揃える。

| action | 変更前 | 変更後 |
|--------|--------|--------|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |

v6/v7 は Node.js 24 ランタイムを使用するため Node.js 20 deprecation 警告が解消される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)