### PR TITLE
fix: address whole-branch code review findings

### DIFF
--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -16,7 +16,6 @@
 """CLI entry point and subcommand routing for junos-ops."""
 
 from jnpr.junos.exception import ConnectClosedError
-from pprint import pprint
 import argparse
 import io
 import sys
@@ -84,8 +83,10 @@ def cmd_facts(hostname) -> int:
     if dev is None:
         return 1
     try:
-        print(f"# {hostname}")
-        pprint(dev.facts)
+        # print_facts emits the header + facts under _print_lock as one
+        # atomic block, so parallel workers (--workers N) cannot interleave
+        # another host's output between this host's header and body.
+        display.print_facts(hostname, dev.facts)
         return 0
     except Exception as e:
         logger.error(f"{hostname}: {e}")
@@ -249,6 +250,9 @@ def cmd_show(hostname) -> int:
             )
         display.print_show(result)
         return 0 if result["ok"] else 1
+    except Exception as e:
+        logger.error(f"{hostname}: {e}")
+        return 1
     finally:
         try:
             dev.close()
@@ -272,7 +276,7 @@ def cmd_config(hostname) -> int:
         if timeout is None:
             try:
                 timeout = int(common.config.get(hostname, "timeout"))
-            except (Exception):
+            except Exception:
                 pass
         if timeout is None:
             timeout = 120

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -226,15 +226,12 @@ def get_targets():
 
     # パターン1: --tags なし & hosts なし → 全セクション（現行動作）
     if not tag_groups and not has_hosts:
-        targets = []
-        for i in config.sections():
-            tmp = config.get(i, "host")
-            logger.debug(f"{i=} {tmp=}")
-            if tmp is not None:
-                targets.append(i)
-            else:
-                print(i, "is not found in", args.config)
-                sys.exit(1)
+        # read_config() guarantees every section has a 'host' option (it
+        # sets it to the section name when absent), so the previous None
+        # check / sys.exit branch here was unreachable.
+        targets = list(config.sections())
+        for i in targets:
+            logger.debug(f"{i=} host={config.get(i, 'host')}")
         return targets
 
     # パターン2: --tags なし & hosts あり → 指定ホストのみ（現行動作）
@@ -344,9 +341,15 @@ def run_parallel(func, targets, max_workers=1):
     When max_workers=1, runs serially for backward compatibility.
     """
     if max_workers <= 1:
+        # Mirror the parallel path's error handling: a raising func records
+        # exit code 1 for that target instead of aborting the whole run.
         results = {}
         for target in targets:
-            results[target] = func(target)
+            try:
+                results[target] = func(target)
+            except Exception as e:
+                logger.error(f"{target} generated an exception: {e}")
+                results[target] = 1
         return results
 
     with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/junos_ops/rsi.py
+++ b/junos_ops/rsi.py
@@ -131,7 +131,9 @@ def collect_rsi(hostname, dev) -> dict:
             else "show configuration"
         )
         output_str = dev.cli(scf_cmd)
-        scf_path = f"{rsi_dir}{hostname}.SCF"
+        # os.path.join (not string concat) so RSI_DIR without a trailing
+        # slash (e.g. "/var/log/rsi") does not produce "/var/log/rsihost.SCF".
+        scf_path = os.path.join(rsi_dir, f"{hostname}.SCF")
         body = output_str.strip()
         with open(scf_path, mode="w") as f:
             f.write(body)
@@ -156,7 +158,7 @@ def collect_rsi(hostname, dev) -> dict:
         output_str = etree.tostring(
             rsi_result["rpc"], encoding="unicode", method="text"
         )
-        rsi_path = f"{rsi_dir}{hostname}.RSI"
+        rsi_path = os.path.join(rsi_dir, f"{hostname}.RSI")
         body = output_str.strip()
         with open(rsi_path, mode="w") as f:
             f.write(body)
@@ -176,16 +178,18 @@ def cmd_rsi(hostname) -> int:
     logger.debug(f"cmd_rsi: {hostname} start")
     from junos_ops import display
 
-    display.print_host_header(hostname)
-
+    # Emit the header + body as one atomic block (print_host_block grabs
+    # _print_lock once) so parallel workers (rsi defaults to --workers 20)
+    # cannot interleave another host's output between this host's header
+    # and its body.
     conn = common.connect(hostname)
     if not conn["ok"]:
-        display.print_connect_error(conn)
+        display.print_host_block(hostname, display.format_connect_error(conn))
         return 1
     dev = conn["dev"]
     try:
         result = collect_rsi(hostname, dev)
-        display.print_rsi(result)
+        display.print_host_block(hostname, display.format_rsi(result))
         return 0 if result["ok"] else (2 if result["error"] == "rsi_rpc" else 1)
     finally:
         try:

--- a/junos_ops/upgrade.py
+++ b/junos_ops/upgrade.py
@@ -1217,6 +1217,14 @@ def compare_version(left: str, right: str) -> int | None:
     :return:  1 if left  > right
               0 if left == right
              -1 if left  < right
+
+    .. note::
+        The ``-S`` spin marker is normalised by replacing ``"-S"`` with
+        ``"00"`` before the LooseVersion comparison. This is reliable for
+        real Junos version strings, but because the substitution simply
+        concatenates the release and spin numbers it can misorder
+        contrived inputs (e.g. ``R30-S9`` vs ``R3-S90``). Callers should
+        only feed it genuine Junos version strings.
     """
     logger.debug(f"compare_version: left={left}, right={right}.")
     if left is None or right is None:
@@ -1278,7 +1286,7 @@ def _pending_from_install_log(hostname, dev, *, quiet: bool = False) -> str | No
     return pending
 
 
-def get_pending_version(hostname, dev) -> str:
+def get_pending_version(hostname, dev) -> str | None:
     """Get pending (staged) version string.
 
     :returns:
@@ -1355,7 +1363,7 @@ def get_pending_version(hostname, dev) -> str:
     return pending
 
 
-def get_planning_version(hostname, dev) -> str:
+def get_planning_version(hostname, dev) -> str | None:
     """Extract planning version from package filename."""
     planning = None
     f = get_model_file(hostname, dev.facts["model"])
@@ -1858,7 +1866,10 @@ def reboot(hostname: str, dev, reboot_dt: datetime.datetime) -> dict:
         result["cleared_existing"] = True
     elif xml_str.find("No shutdown/reboot scheduled.") < 0:
         logger.debug("ANY SHUTDWON/REBOOT SCHEDULE EXISTS")
-        match = re.search(r"^(\w+) requested by (\w+) at (.*)$", xml_str, re.MULTILINE)
+        # Username uses \S+ (not \w+) so accounts containing '-', '.', '@'
+        # still match; otherwise an existing schedule would silently fail
+        # to parse here and never get cleared, even with --force.
+        match = re.search(r"^(\w+) requested by (\S+) at (.*)$", xml_str, re.MULTILINE)
         if match and len(match.groups()) == 3:
             dt = datetime.datetime.strptime(match.group(3), "%a %b %d %H:%M:%S %Y")
             existing_msg = f"\t{match.group(1).upper()} SCHEDULE EXISTS AT {dt}"

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -282,6 +282,34 @@ class TestCmdRsi:
         m.assert_any_call("./test-host.SCF", mode="w")
         m.assert_any_call("./test-host.RSI", mode="w")
 
+    def test_rsi_dir_without_trailing_slash(self, junos_common, mock_args, mock_config):
+        """RSI_DIR without a trailing slash still resolves correctly (os.path.join)."""
+        import os
+        mock_config.set("test-host", "RSI_DIR", "/var/log/rsi")
+        mock_dev = MagicMock()
+        mock_dev.cli.return_value = "config"
+        rsi_xml = etree.Element("output")
+        rsi_xml.text = "RSI text"
+        mock_dev.rpc.get_support_information.return_value = rsi_xml
+        mock_dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-host",
+            "srx_cluster": None,
+        }
+
+        m = mock_open()
+        with patch.object(rsi.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
+            with patch("builtins.open", m):
+                result = rsi.cmd_rsi("test-host")
+
+        assert result == 0
+        # String concat would give "/var/log/rsitest-host.SCF"; os.path.join
+        # inserts the separator correctly.
+        m.assert_any_call(os.path.join("/var/log/rsi", "test-host.SCF"), mode="w")
+        m.assert_any_call(os.path.join("/var/log/rsi", "test-host.RSI"), mode="w")
+
     def test_rsi_dir_tilde_expansion(self, junos_common, mock_args, mock_config):
         """RSI_DIR の ~ がホームディレクトリに展開される"""
         import os
@@ -308,3 +336,35 @@ class TestCmdRsi:
         expected_dir = os.path.expanduser("~/rsi/")
         m.assert_any_call(f"{expected_dir}test-host.SCF", mode="w")
         m.assert_any_call(f"{expected_dir}test-host.RSI", mode="w")
+
+    def test_cmd_rsi_emits_atomic_block(self, junos_common, mock_args, mock_config):
+        """cmd_rsi emits the header + body via print_host_block.
+
+        rsi defaults to --workers 20, so the header and body must be written
+        as one atomic block (not a standalone print_host_header call) to keep
+        another host's output from interleaving between them.
+        """
+        mock_dev = MagicMock()
+        mock_dev.cli.return_value = "config"
+        rsi_xml = etree.Element("output")
+        rsi_xml.text = "RSI text"
+        mock_dev.rpc.get_support_information.return_value = rsi_xml
+        mock_dev.facts = {
+            "personality": "MX",
+            "model": "MX204",
+            "model_info": {"MX204": {}},
+            "hostname": "test-host",
+            "srx_cluster": None,
+        }
+
+        m = mock_open()
+        with patch.object(rsi.common, "connect", return_value={"hostname": "test-host", "host": "test-host", "ok": True, "dev": mock_dev, "error": None, "error_message": None}):
+            with patch("builtins.open", m):
+                with patch("junos_ops.display.print_host_block") as mock_block, \
+                        patch("junos_ops.display.print_host_header") as mock_header:
+                    result = rsi.cmd_rsi("test-host")
+
+        assert result == 0
+        mock_block.assert_called_once()
+        assert mock_block.call_args[0][0] == "test-host"
+        mock_header.assert_not_called()

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -368,3 +368,29 @@ class TestCmdRsi:
         mock_block.assert_called_once()
         assert mock_block.call_args[0][0] == "test-host"
         mock_header.assert_not_called()
+
+    def test_cmd_rsi_connect_error_uses_atomic_block(self, junos_common, mock_args, mock_config):
+        """On connect failure, cmd_rsi still emits header + error via print_host_block.
+
+        The error path must use the same atomic block as the success path
+        (not the standalone print_connect_error) so a failed host's output
+        does not interleave with other hosts under --workers.
+        """
+        conn = {
+            "hostname": "test-host",
+            "host": "test-host",
+            "ok": False,
+            "dev": None,
+            "error": "ConnectTimeoutError",
+            "error_message": "Connection timeout: test-host",
+        }
+        with patch.object(rsi.common, "connect", return_value=conn):
+            with patch("junos_ops.display.print_host_block") as mock_block, \
+                    patch("junos_ops.display.print_connect_error") as mock_pce:
+                result = rsi.cmd_rsi("test-host")
+
+        assert result == 1
+        mock_block.assert_called_once()
+        assert mock_block.call_args[0][0] == "test-host"
+        # The standalone (non-atomic) connect-error printer must not be used.
+        mock_pce.assert_not_called()


### PR DESCRIPTION
main ブランチ全体のコードレビューで挙がった所見への対応です。

## 🔴 並列実行時の実害

- **`cmd_facts` / `cmd_rsi` の出力 atomic 化** — どちらも `# host` ヘッダと本体を別々に出力しており、`--workers N`（rsi はデフォルト 20）で他ホストの出力と混線しうる。既存の `print_host_block` / `print_facts`（後者は実装済み・未使用だった）に統一。
- **`RSI_DIR` のパス連結** — 文字列結合のため末尾スラッシュ無し（`/var/log/rsi`）だと `/var/log/rsihost.SCF` になる。`os.path.join` に変更。

## 🟡 軽微

- `reboot` の既存スケジュール解析正規表現で、ユーザ名部を `(\w+)` → `(\S+)` に（`-`/`.`/`@` を含むアカウントでも解析・`--force` clear が効く）。
- `run_parallel` のシリアルパスでも例外を捕捉（並列パスと挙動を統一）。
- `cmd_show` に `except` を追加（他サブコマンドと統一）。
- `get_targets` パターン1 の到達不能な `None`/`sys.exit` 分岐を整理。
- `get_pending_version` / `get_planning_version` の型ヒントを `-> str | None` に。
- `except (Exception)` → `except Exception:`。

## 📝 ドキュメント

- `compare_version` の `-S` → `00` 正規化の制約を docstring に明記。

## ✅ テスト

- RSI_DIR 末尾スラッシュ無しのパス、`cmd_rsi` の atomic 出力の回帰テストを 2 件追加。
- 全 319 テスト pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)