### PR TITLE
docs: note the atomic-output convention for new subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,3 +229,4 @@ junos-ops upgrade --unlink ex3400-host.example.jp
 - `args`と`config`は`common`モジュールのグローバル変数として管理される
 - `config`への書き込みは`config_lock`（threading.Lock）で保護済み
 - `cli.py`の後方互換alias（`copy = upgrade.copy` 等）は将来のバージョンで削除予定
+- 新しいサブコマンドは出力を`display.print_host_block(hostname, body)`（または`print_facts`）で**1ブロックとして atomic に出力**すること。`print_host_header`単独 + 別の`print_*`/`print()`に分けると、`--workers N`並列実行時に他ホストの出力がヘッダと本体の間に割り込む。`cmd_facts`/`cmd_rsi`がこの不具合を抱えており v0.23.1 で修正済み


### PR DESCRIPTION
v0.23.1 で `cmd_facts` / `cmd_rsi` が並列実行時に出力をインターリーブさせる不具合を修正した（`print_host_block` への統一）。同種の漏れを防ぐため、CLAUDE.md の「既知の注意事項」に **新しいサブコマンドは `display.print_host_block` / `print_facts` で出力を 1 ブロックとして atomic に出力する**規約を明記する。

ドキュメントのみの変更（コードへの影響なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)