### PR TITLE
feat(cli): add --json machine-readable output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ LICENSE
 
 ### display.py — 表示層
 - `print_version()`, `print_copy()`, `print_install()`, `print_rollback()`, `print_reboot()`, `print_reinstall()`, `print_load_config()`, `print_list_remote()`, `print_dry_run()`, `print_rsi()`, `print_show()`, `print_connect_error()`, `print_read_config_error()`, `print_host_header()`, `print_host_footer()` — core が返す dict を人間向けに整形
+- `format_json(hostname, result)` / `print_json(hostname, result)` — core dict を `{"hostname": ..., **result}` の 1 行 JSON にシリアライズ（`--json` 用）。`format_json_obj(obj)` / `print_json_obj(obj)` は hostname を注入せず obj をそのまま出す（`check` の model 単位 row 用）。`json.dumps(..., default=str, ensure_ascii=False)` で lxml/datetime 等の非シリアライズ値も str fallback、非 ASCII はそのまま
 - `_print_lock` (`threading.Lock`) でマルチワーカー時の出力インターリーブを防止
 - junos-mcp など非 CLI 利用者は display を import しなければ stdout 出力ゼロ
 
@@ -104,7 +105,9 @@ LICENSE
 - `main()` — argparse サブコマンド定義、ディスパッチ
 - `cmd_upgrade()`, `cmd_copy()`, `cmd_install()`, `cmd_rollback()`, `cmd_version()`, `cmd_reboot()`, `cmd_ls()`, `cmd_show()`, `cmd_config()`, `cmd_facts()` — サブコマンド用エントリ関数（connect → header → core(dict) → display）
 - `_check_host(hostname)` — `check` サブコマンド用ワーカー。int ではなく dict を返し、`main()` で結果を集約して `display.print_check_table` にテーブル出力。モデル解決順: `--model` > `config.ini [host].model` > `dev.facts["model"]`
-- `_open_connection()` — NETCONF 接続＋エラー時の display 出力ヘルパー
+- `_open_connection()` — NETCONF 接続＋エラー時の display 出力ヘルパー（`--json` 時は connect エラーを JSON で出す）
+- `--json` グローバルオプション: 各 `cmd_*` は `_emit_result(hostname, result, formatter)` で「`--json` なら `display.print_json`、通常は `display.print_host_block(formatter(result))`」を分岐。失敗ホストは `_emit_exception` が `{"ok": false, "error", "error_message"}` の JSON 行を出す（JSONL consumer が行欠落で気づけないのを防ぐ）。出力は host ごと 1 行の JSONL（`run_parallel` で並列のため top-level 配列は作らない。`jq -s` で slurp）
+- `_route_logs_to_stderr()` — `--json` 時に root logger の stdout 向け StreamHandler を stderr へ移す。`logging.ini` の consoleHandler も fallback の basicConfig も stdout に出力するため、これをやらないと `load_config` の `logger.info` 進捗等が JSON を汚す。`_run()` で `common.args` 設定直後に呼ぶ
 
 ## CLI設計
 
@@ -124,7 +127,7 @@ junos-ops [hostname ...]                   # サブコマンド省略 → device
 junos-ops --version                        # プログラムバージョン
 ```
 
-共通オプション: `--config` (`-c`), `--dry-run` (`-n`), `-d`, `--force`, `--workers N`, `--tags TAG,...`
+共通オプション: `--config` (`-c`), `--dry-run` (`-n`), `-d`, `--force`, `--workers N`, `--tags TAG,...`, `--json`（機械可読 JSONL 出力。ログは stderr へ退避）
 
 ## 開発環境セットアップ
 
@@ -228,5 +231,4 @@ junos-ops upgrade --unlink ex3400-host.example.jp
 
 - `args`と`config`は`common`モジュールのグローバル変数として管理される
 - `config`への書き込みは`config_lock`（threading.Lock）で保護済み
-- `cli.py`の後方互換alias（`copy = upgrade.copy` 等）は将来のバージョンで削除予定
 - 新しいサブコマンドは出力を`display.print_host_block(hostname, body)`（または`print_facts`）で**1ブロックとして atomic に出力**すること。`print_host_header`単独 + 別の`print_*`/`print()`に分けると、`--workers N`並列実行時に他ホストの出力がヘッダと本体の間に割り込む。`cmd_facts`/`cmd_rsi`がこの不具合を抱えており v0.23.1 で修正済み

--- a/README.ja.md
+++ b/README.ja.md
@@ -236,7 +236,7 @@ $ junos-ops version --json rt1.example.jp rt2.example.jp
 {"hostname": "rt2.example.jp", "ok": true, "model": "EX2300-24T", "running": "22.4R3-S6.5", ...}
 ```
 
-- ログ（`config` のコミット進捗を含む）は **stderr** に出力されるため、`2>/dev/null` や stdout のみのパイプで純粋な JSON だけが得られます。
+- ログ（`config` のコミット進捗を含む）および起動時の診断（設定ファイル読込失敗、対象ホスト 0 件）は **stderr** に出力されるため、`2>/dev/null` や stdout のみのパイプで純粋な JSON だけが得られます。起動失敗は終了コードで判定してください（その場合 stdout は空）。
 - 接続失敗や実行中エラーのホストも 1 行を出力します（`{"hostname": ..., "ok": false, "error": ..., "error_message": ...}`）。consumer がホストの取りこぼしに気づけます。
 - `jq -s` で 1 つの配列に集約: `junos-ops version --json | jq -s '.'`
 - `check --json` は各行に `"check": "local"`（model 単位のインベントリ行）または `"check": "host"`（ホスト単位の行）を付与します。

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@ Juniper/JUNOS デバイスの運用を NETCONF 経由で自動化する Python C
 - `--tags` によるタグベースのホストフィルタ（AND マッチ）
 - ローカルファームウェア置き場（`lpath`、`~` 展開対応）
 - ドライランモード（`--dry-run`）で事前確認
+- 機械可読な JSON 出力（`--json`）で jq / 監視 / Ansible 連携
 - ThreadPoolExecutor による並列実行（`--workers N`）
 - 設定ファイル（INI 形式）によるホスト・パッケージ管理
 
@@ -220,9 +221,25 @@ junos-ops <subcommand> [options] [hostname ...]
 | `-n`, `--dry-run` | テスト実行（接続とメッセージ出力のみ、実行しない） |
 | `-d`, `--debug` | デバッグ出力 |
 | `--force` | 条件を無視して強制実行 |
+| `--json` | 人間向けテキストの代わりに機械可読 JSON を出力。ホストごとに 1 行の JSON オブジェクト（JSONL）。ログは stderr に退避されるため stdout は純粋な JSON のみ。`jq -s` で配列に slurp 可能。詳細は「JSON 出力」セクション参照 |
 | `--tags TAG[,TAG...]` | タグでホストをフィルタ。カンマ区切りは 1 グループ内の AND、`--tags` の繰り返しはグループ間 OR。ホスト名併記時はタグフィルタと積集合。詳細は「タグベースのホストフィルタリング」セクション参照 |
 | `--workers N` | 並列実行数（デフォルト: upgrade系=1, rsi=20） |
 | `--version` | プログラムバージョン表示 |
+
+### JSON 出力
+
+任意のサブコマンドに `--json` を付けると機械可読出力が得られます。ホストごとに 1 行の JSON オブジェクト（JSON Lines / JSONL）を出力するため、`--workers N` での並列実行とも自然に組み合わせられます。
+
+```console
+$ junos-ops version --json rt1.example.jp rt2.example.jp
+{"hostname": "rt1.example.jp", "ok": true, "model": "MX240", "running": "22.4R3-S6.5", ...}
+{"hostname": "rt2.example.jp", "ok": true, "model": "EX2300-24T", "running": "22.4R3-S6.5", ...}
+```
+
+- ログ（`config` のコミット進捗を含む）は **stderr** に出力されるため、`2>/dev/null` や stdout のみのパイプで純粋な JSON だけが得られます。
+- 接続失敗や実行中エラーのホストも 1 行を出力します（`{"hostname": ..., "ok": false, "error": ..., "error_message": ...}`）。consumer がホストの取りこぼしに気づけます。
+- `jq -s` で 1 つの配列に集約: `junos-ops version --json | jq -s '.'`
+- `check --json` は各行に `"check": "local"`（model 単位のインベントリ行）または `"check": "host"`（ホスト単位の行）を付与します。
 
 ## ワークフロー
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ $ junos-ops version --json rt1.example.jp rt2.example.jp
 {"hostname": "rt2.example.jp", "ok": true, "model": "EX2300-24T", "running": "22.4R3-S6.5", ...}
 ```
 
-- Logs (including `config`'s real-time commit progress) go to **stderr**, so `2>/dev/null` or piping stdout alone yields valid JSON only.
+- Logs (including `config`'s real-time commit progress) and startup diagnostics (unreadable config, no matching hosts) go to **stderr**, so `2>/dev/null` or piping stdout alone yields valid JSON only. Check the exit code to detect a startup failure (stdout is then empty).
 - A host that fails to connect or errors mid-run still emits a line — `{"hostname": ..., "ok": false, "error": ..., "error_message": ...}` — so a consumer never silently misses a host.
 - Slurp the stream into a single array with `jq -s`: `junos-ops version --json | jq -s '.'`
 - `check --json` tags each line with `"check": "local"` (model-keyed inventory rows) or `"check": "host"` (per-host rows).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Python CLI to automate Juniper/JUNOS operations over NETCONF: model-aware upgr
 - Tag-based host filtering (`--tags`) for AND-matched multi-site workflows
 - Local firmware directory (`lpath`) with `~` expansion
 - Dry-run mode (`--dry-run`) for pre-flight verification
+- Machine-readable JSON output (`--json`) for piping into jq / monitoring / Ansible
 - Parallel execution via ThreadPoolExecutor (`--workers N`)
 - INI-based host and package management
 
@@ -220,9 +221,25 @@ junos-ops <subcommand> [options] [hostname ...]
 | `-n`, `--dry-run` | Test run (connect and display messages only, no execution) |
 | `-d`, `--debug` | Debug output |
 | `--force` | Force execution regardless of conditions |
+| `--json` | Emit machine-readable JSON instead of human-readable text. One JSON object per host per line (JSONL); logs are routed to stderr so stdout stays pure JSON. Pipe to `jq -s` to slurp into an array. See "JSON Output" below. |
 | `--tags TAG[,TAG...]` | Filter hosts by tags. Comma-separates AND together inside one value; repeating `--tags` ORs groups. Combined with explicit hostnames, the tag filter and hostname list intersect. See "Tag-based Host Filtering" below. |
 | `--workers N` | Parallel workers (default: 1 for upgrade, 20 for rsi) |
 | `--version` | Show program version |
+
+### JSON Output
+
+Pass `--json` to any subcommand to get machine-readable output. Each host emits one JSON object on its own line (JSON Lines / JSONL), which composes cleanly with parallel `--workers N` runs:
+
+```console
+$ junos-ops version --json rt1.example.jp rt2.example.jp
+{"hostname": "rt1.example.jp", "ok": true, "model": "MX240", "running": "22.4R3-S6.5", ...}
+{"hostname": "rt2.example.jp", "ok": true, "model": "EX2300-24T", "running": "22.4R3-S6.5", ...}
+```
+
+- Logs (including `config`'s real-time commit progress) go to **stderr**, so `2>/dev/null` or piping stdout alone yields valid JSON only.
+- A host that fails to connect or errors mid-run still emits a line — `{"hostname": ..., "ok": false, "error": ..., "error_message": ...}` — so a consumer never silently misses a host.
+- Slurp the stream into a single array with `jq -s`: `junos-ops version --json | jq -s '.'`
+- `check --json` tags each line with `"check": "local"` (model-keyed inventory rows) or `"check": "host"` (per-host rows).
 
 ## Workflow
 

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -993,7 +993,11 @@ def _run():
 
     cfg_result = common.read_config()
     if not cfg_result["ok"]:
-        display.print_read_config_error(cfg_result)
+        if _json_mode():
+            # Startup error → diagnostic on stderr so stdout stays pure JSON.
+            print(display.format_read_config_error(cfg_result), file=sys.stderr)
+        else:
+            display.print_read_config_error(cfg_result)
         sys.exit(1)
 
     targets = common.get_targets()

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -64,6 +64,53 @@ from junos_ops import show  # noqa: E402
 # --- サブコマンド用エントリ関数 ---
 
 
+def _json_mode() -> bool:
+    """Return True when ``--json`` machine-readable output is requested."""
+    return getattr(common.args, "json", False)
+
+
+def _route_logs_to_stderr() -> None:
+    """Redirect any stdout-bound logging StreamHandler to stderr.
+
+    Under ``--json`` stdout must carry only JSON lines, but both the
+    shipped logging.ini console handler and the basicConfig fallback
+    write log records to stdout — and ``load_config`` streams progress
+    via ``logger.info``. Moving those handlers to stderr keeps logs as
+    diagnostics while stdout stays machine-parseable. A file handler's
+    stream is not ``sys.stdout`` so it is left untouched.
+    """
+    for h in logging.getLogger().handlers:
+        if isinstance(h, logging.StreamHandler) and getattr(h, "stream", None) is sys.stdout:
+            h.setStream(sys.stderr)
+
+
+def _emit_result(hostname: str, result: dict, formatter) -> None:
+    """Emit a core result as a JSON line (``--json``) or formatted text.
+
+    ``formatter`` is the matching ``display.format_*`` callable used for
+    the human-readable path.
+    """
+    if _json_mode():
+        display.print_json(hostname, result)
+    else:
+        display.print_host_block(hostname, formatter(result))
+
+
+def _emit_exception(hostname: str, exc: Exception) -> None:
+    """Report a worker-level exception as JSON (``--json``) or a log record.
+
+    In JSON mode a failed host emits an explicit error object so a JSONL
+    consumer sees a record rather than a silently missing line.
+    """
+    if _json_mode():
+        display.print_json(
+            hostname,
+            {"ok": False, "error": type(exc).__name__, "error_message": str(exc)},
+        )
+    else:
+        logger.error(f"{hostname}: {exc}")
+
+
 def _open_connection(hostname: str):
     """Open a NETCONF connection and render any error via the display layer.
 
@@ -72,7 +119,18 @@ def _open_connection(hostname: str):
     """
     conn = common.connect(hostname)
     if not conn["ok"]:
-        display.print_host_block(hostname, display.format_connect_error(conn))
+        if _json_mode():
+            display.print_json(
+                hostname,
+                {
+                    "ok": False,
+                    "phase": "connect",
+                    "error": conn.get("error"),
+                    "error_message": conn.get("error_message"),
+                },
+            )
+        else:
+            display.print_host_block(hostname, display.format_connect_error(conn))
         return None
     return conn["dev"]
 
@@ -83,13 +141,16 @@ def cmd_facts(hostname) -> int:
     if dev is None:
         return 1
     try:
-        # print_facts emits the header + facts under _print_lock as one
-        # atomic block, so parallel workers (--workers N) cannot interleave
-        # another host's output between this host's header and body.
-        display.print_facts(hostname, dev.facts)
+        if _json_mode():
+            display.print_json(hostname, dict(dev.facts))
+        else:
+            # print_facts emits the header + facts under _print_lock as one
+            # atomic block, so parallel workers (--workers N) cannot interleave
+            # another host's output between this host's header and body.
+            display.print_facts(hostname, dev.facts)
         return 0
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -105,10 +166,10 @@ def cmd_upgrade(hostname) -> int:
         return 1
     try:
         result = upgrade.install(hostname, dev)
-        display.print_host_block(hostname, display.format_install(result))
+        _emit_result(hostname, result, display.format_install)
         return 0 if result.get("ok") else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -124,10 +185,10 @@ def cmd_copy(hostname) -> int:
         return 1
     try:
         result = upgrade.copy(hostname, dev)
-        display.print_host_block(hostname, display.format_copy(result))
+        _emit_result(hostname, result, display.format_copy)
         return 0 if result.get("ok") else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -143,10 +204,10 @@ def cmd_install(hostname) -> int:
         return 1
     try:
         result = upgrade.install(hostname, dev)
-        display.print_host_block(hostname, display.format_install(result))
+        _emit_result(hostname, result, display.format_install)
         return 0 if result.get("ok") else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -162,12 +223,22 @@ def cmd_rollback(hostname) -> int:
         return 1
     try:
         pending = upgrade.get_pending_version(hostname, dev)
-        lines = [f"rollback: pending version is {pending}"]
         if pending is None:
-            lines.append("rollback: skip")
-            display.print_host_block(hostname, "\n".join(lines))
+            if _json_mode():
+                display.print_json(
+                    hostname, {"ok": True, "pending": None, "skipped": True}
+                )
+            else:
+                display.print_host_block(
+                    hostname,
+                    "rollback: pending version is None\nrollback: skip",
+                )
             return 0
         result = upgrade.rollback(hostname, dev)
+        if _json_mode():
+            display.print_json(hostname, {"pending": pending, **result})
+            return 0 if result.get("ok") else 1
+        lines = [f"rollback: pending version is {pending}"]
         rb = display.format_rollback(result)
         if rb:
             lines.append(rb)
@@ -176,7 +247,7 @@ def cmd_rollback(hostname) -> int:
         display.print_host_block(hostname, "\n".join(lines))
         return 0 if result.get("ok") else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -192,10 +263,10 @@ def cmd_version(hostname) -> int:
         return 1
     try:
         result = upgrade.show_version(hostname, dev)
-        display.print_host_block(hostname, display.format_version(result))
+        _emit_result(hostname, result, display.format_version)
         return 0
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -211,10 +282,10 @@ def cmd_reboot(hostname) -> int:
         return 1
     try:
         result = upgrade.reboot(hostname, dev, common.args.rebootat)
-        display.print_host_block(hostname, display.format_reboot(result))
+        _emit_result(hostname, result, display.format_reboot)
         return result.get("code", 1)
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -248,10 +319,13 @@ def cmd_show(hostname) -> int:
                 retry=retry,
                 hostname=hostname,
             )
-        display.print_show(result)
+        if _json_mode():
+            display.print_json(hostname, result)
+        else:
+            display.print_show(result)
         return 0 if result["ok"] else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -263,9 +337,13 @@ def cmd_show(hostname) -> int:
 def cmd_config(hostname) -> int:
     """Push set command file to device."""
     if getattr(common.args, "no_commit", False) and getattr(common.args, "no_confirm", False):
-        display.print_host_block(
-            hostname, "\t--no-commit and --no-confirm are mutually exclusive"
-        )
+        msg = "--no-commit and --no-confirm are mutually exclusive"
+        if _json_mode():
+            display.print_json(
+                hostname, {"ok": False, "error": "MutuallyExclusiveArgs", "error_message": msg}
+            )
+        else:
+            display.print_host_block(hostname, f"\t{msg}")
         return 1
     dev = _open_connection(hostname)
     if dev is None:
@@ -282,10 +360,10 @@ def cmd_config(hostname) -> int:
             timeout = 120
         dev.timeout = timeout
         result = upgrade.load_config(hostname, dev, common.args.configfile)
-        display.print_host_block(hostname, display.format_load_config(result))
+        _emit_result(hostname, result, display.format_load_config)
         return 0 if result.get("ok") else 1
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -532,10 +610,10 @@ def cmd_ls(hostname) -> int:
         return 1
     try:
         result = upgrade.list_remote_path(hostname, dev)
-        display.print_host_block(hostname, display.format_list_remote(result))
+        _emit_result(hostname, result, display.format_list_remote)
         return 0
     except Exception as e:
-        logger.error(f"{hostname}: {e}")
+        _emit_exception(hostname, e)
         return 1
     finally:
         try:
@@ -569,6 +647,14 @@ def _run():
         help="connect and message output. No execute.",
     )
     parent.add_argument("-d", "--debug", action="store_true", help="debug output")
+    parent.add_argument(
+        "--json", action="store_true",
+        help=(
+            "emit machine-readable JSON instead of human-readable text "
+            "(one JSON object per host per line; pipe to `jq -s` to slurp). "
+            "Logs are redirected to stderr so stdout stays pure JSON."
+        ),
+    )
     parent.add_argument(
         "--force", action="store_true", help="force execute",
     )
@@ -828,6 +914,8 @@ def _run():
             args.subcommand = None
 
     # 後方互換属性の設定
+    if not hasattr(args, "json"):
+        args.json = False
     if not hasattr(args, "list_format"):
         args.list_format = None
     if not hasattr(args, "rebootat"):
@@ -897,6 +985,10 @@ def _run():
     if common.args.config is None:
         common.args.config = common.get_default_config()
 
+    # --json: stdout must carry only JSON, so move log records to stderr.
+    if _json_mode():
+        _route_logs_to_stderr()
+
     logger.debug("start")
 
     cfg_result = common.read_config()
@@ -918,30 +1010,43 @@ def _run():
     if args.subcommand == "check":
         rc = 0
 
+        json_mode = _json_mode()
+
         # --local: staging server 側のファームウェア棚卸し（ホスト非依存）
         if common.args.check_local:
             inventory = _check_local_inventory()
-            display.print_check_local_inventory(inventory)
+            if json_mode:
+                # Inventory rows are model-keyed, not host-keyed; emit each
+                # as-is (it already carries a "model" field).
+                for row in inventory:
+                    display.print_json_obj({"check": "local", **row})
+            else:
+                display.print_check_local_inventory(inventory)
             for row in inventory:
                 if row.get("status") in ("bad", "missing", "error"):
                     rc = 1
 
         # --connect / --remote: ホスト単位でチェック
         if common.args.check_connect or common.args.check_remote:
-            if common.args.check_local:
+            if common.args.check_local and not json_mode:
                 # 2 つ目のテーブルの前にブランク行
                 print("")
             results = _run_check_with_progress(
                 targets, max_workers=common.args.workers
             )
             rows = [results[t] for t in targets if t in results]
-            display.print_check_table(
-                rows,
-                show_connect=common.args.check_connect,
-                show_local=False,
-                show_remote=common.args.check_remote,
-                show_disk=common.args.check_connect or common.args.check_remote,
-            )
+            if json_mode:
+                # Per-host rows already carry "hostname"; emit each as a line.
+                for row in rows:
+                    display.print_json_obj({"check": "host", **row})
+            else:
+                display.print_check_table(
+                    rows,
+                    show_connect=common.args.check_connect,
+                    show_local=False,
+                    show_remote=common.args.check_remote,
+                    show_disk=common.args.check_connect or common.args.check_remote,
+                )
             for row in rows:
                 if not isinstance(row, dict):
                     rc = 1

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -222,6 +222,14 @@ def get_targets():
     tags = getattr(args, "tags", None)
     has_hosts = len(args.specialhosts) > 0
 
+    def _fatal(*parts):
+        # Startup/selection errors are diagnostics, not data. Under --json
+        # they must not land on stdout (which carries only JSON), so route
+        # them to stderr; otherwise keep the legacy stdout behaviour.
+        stream = sys.stderr if getattr(args, "json", False) else sys.stdout
+        print(*parts, file=stream)
+        sys.exit(1)
+
     tag_groups = _parse_tag_groups(tags)
 
     # パターン1: --tags なし & hosts なし → 全セクション（現行動作）
@@ -241,8 +249,7 @@ def get_targets():
             if config.has_section(i):
                 tmp = config.get(i, "host")
             else:
-                print(i, "is not found in", args.config)
-                sys.exit(1)
+                _fatal(i, "is not found in", args.config)
             logger.debug(f"{i=} {tmp=}")
             targets.append(i)
         return targets
@@ -254,8 +261,7 @@ def get_targets():
     if tag_groups and not has_hosts:
         targets = _filter_by_tag_groups(tag_groups)
         if not targets:
-            print("no hosts matched tags:", tags)
-            sys.exit(1)
+            _fatal("no hosts matched tags:", tags)
         return targets
 
     # Pattern 4: --tags + hosts -> intersection (tag filter AND name list).
@@ -265,13 +271,11 @@ def get_targets():
     targets = []
     for i in args.specialhosts:
         if not config.has_section(i):
-            print(i, "is not found in", args.config)
-            sys.exit(1)
+            _fatal(i, "is not found in", args.config)
         if i in tag_matched:
             targets.append(i)
     if not targets:
-        print("no hosts matched both tags and names:", tags, args.specialhosts)
-        sys.exit(1)
+        _fatal("no hosts matched both tags and names:", tags, args.specialhosts)
     return targets
 
 

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -71,6 +71,42 @@ def _emit(text: str) -> None:
 # -------------------------------------------------------------------
 
 
+def format_json_obj(obj) -> str:
+    """Serialize ``obj`` to a single-line JSON string.
+
+    ``default=str`` is the safety net for values core dicts may carry
+    that are not natively JSON-serializable (lxml elements, datetimes,
+    PyEZ version tuples). ``ensure_ascii=False`` keeps non-ASCII text
+    (e.g. config diffs) readable rather than escaped.
+    """
+    return json.dumps(obj, default=str, ensure_ascii=False)
+
+
+def print_json_obj(obj) -> None:
+    """Emit ``obj`` as one atomic JSON line under the print lock."""
+    _emit(format_json_obj(obj))
+
+
+def format_json(hostname: str, result) -> str:
+    """Serialize a per-host core result to a single JSON line.
+
+    The host is surfaced as a top-level ``hostname`` key so a JSONL
+    consumer can attribute each line without external state. A dict
+    result is merged in (its own ``hostname``, if any, carries the same
+    value); a non-dict result is wrapped under a ``result`` key.
+    """
+    if isinstance(result, dict):
+        payload = {"hostname": hostname, **result}
+    else:
+        payload = {"hostname": hostname, "result": result}
+    return format_json_obj(payload)
+
+
+def print_json(hostname: str, result) -> None:
+    """Emit a per-host core result as one atomic JSON line."""
+    _emit(format_json(hostname, result))
+
+
 def format_host_header(hostname: str) -> str:
     """Return the ``# hostname`` header line (no trailing newline)."""
     return f"# {hostname}"

--- a/junos_ops/rsi.py
+++ b/junos_ops/rsi.py
@@ -182,14 +182,29 @@ def cmd_rsi(hostname) -> int:
     # _print_lock once) so parallel workers (rsi defaults to --workers 20)
     # cannot interleave another host's output between this host's header
     # and its body.
+    json_mode = getattr(common.args, "json", False)
     conn = common.connect(hostname)
     if not conn["ok"]:
-        display.print_host_block(hostname, display.format_connect_error(conn))
+        if json_mode:
+            display.print_json(
+                hostname,
+                {
+                    "ok": False,
+                    "phase": "connect",
+                    "error": conn.get("error"),
+                    "error_message": conn.get("error_message"),
+                },
+            )
+        else:
+            display.print_host_block(hostname, display.format_connect_error(conn))
         return 1
     dev = conn["dev"]
     try:
         result = collect_rsi(hostname, dev)
-        display.print_host_block(hostname, display.format_rsi(result))
+        if json_mode:
+            display.print_json(hostname, result)
+        else:
+            display.print_host_block(hostname, display.format_rsi(result))
         return 0 if result["ok"] else (2 if result["error"] == "rsi_rpc" else 1)
     finally:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def mock_args(junos_common):
         debug=False,
         dry_run=False,
         force=False,
+        json=False,
         config="config.ini",
         list_format=None,
         rebootat=None,

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -78,6 +78,61 @@ class TestRouteLogsToStderr:
         finally:
             root.removeHandler(h)
 
+    def test_run_wires_rerouting_under_json(self, capsys, monkeypatch):
+        """_run() itself must call the rerouting under --json.
+
+        Drives the full dispatcher via ``check --json --local`` (no device
+        needed) so removing the ``_route_logs_to_stderr()`` call from _run
+        is caught here, not only by a manual smoke test.
+        """
+        root = logging.getLogger()
+        console = logging.StreamHandler(sys.stdout)
+        root.addHandler(console)
+        monkeypatch.setattr(
+            sys, "argv", ["junos-ops", "check", "--json", "--local"]
+        )
+        try:
+            cli._run()
+        finally:
+            root.removeHandler(console)
+        # The production wiring moved our stdout-attached handler to stderr.
+        assert console.stream is sys.stderr
+        # stdout carries only JSON lines.
+        for ln in capsys.readouterr().out.splitlines():
+            if ln.strip():
+                json.loads(ln)
+
+
+class TestGetTargetsJsonFatal:
+    """get_targets startup errors stay off stdout under --json."""
+
+    def test_unknown_host_diagnostic_goes_to_stderr(
+        self, capsys, mock_args, mock_config
+    ):
+        import pytest
+
+        mock_args.json = True
+        mock_args.specialhosts = ["no-such-host"]
+        with pytest.raises(SystemExit) as exc:
+            common.get_targets()
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        # stdout must stay pure JSON (here: empty); the diagnostic is on stderr.
+        assert captured.out == ""
+        assert "no-such-host" in captured.err
+
+    def test_unknown_host_diagnostic_on_stdout_without_json(
+        self, capsys, mock_args, mock_config
+    ):
+        import pytest
+
+        mock_args.json = False
+        mock_args.specialhosts = ["no-such-host"]
+        with pytest.raises(SystemExit):
+            common.get_targets()
+        # Legacy behaviour preserved: human mode still prints to stdout.
+        assert "no-such-host" in capsys.readouterr().out
+
 
 class TestCmdJsonOutput:
     """cmd_* honour --json and keep stdout machine-parseable."""

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,0 +1,195 @@
+"""--json machine-readable output tests.
+
+Covers the display-layer JSON serializers and the CLI integration that
+must keep stdout pure JSON (logs rerouted to stderr) so the output is
+safe to pipe into jq / Ansible.
+"""
+
+import datetime
+import json
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+from junos_ops import cli
+from junos_ops import common
+from junos_ops import display
+
+
+class TestFormatJson:
+    """display.format_json / format_json_obj unit tests."""
+
+    def test_dict_result_merges_hostname(self):
+        """A dict result is surfaced with a top-level hostname key."""
+        line = display.format_json("rt1", {"ok": True, "running": "22.4R3"})
+        obj = json.loads(line)
+        assert obj == {"hostname": "rt1", "ok": True, "running": "22.4R3"}
+
+    def test_non_dict_result_wrapped(self):
+        """A non-dict result is wrapped under a result key."""
+        obj = json.loads(display.format_json("rt1", "raw text"))
+        assert obj == {"hostname": "rt1", "result": "raw text"}
+
+    def test_single_line(self):
+        """The serialized form is exactly one line (JSONL-safe)."""
+        line = display.format_json("rt1", {"a": 1, "b": {"c": 2}})
+        assert "\n" not in line
+
+    def test_non_ascii_preserved(self):
+        """ensure_ascii=False keeps non-ASCII text readable, not escaped."""
+        line = display.format_json("rt1", {"diff": "ポート設定"})
+        assert "ポート設定" in line
+        assert json.loads(line)["diff"] == "ポート設定"
+
+    def test_non_serializable_falls_back_to_str(self):
+        """default=str rescues values json cannot natively serialize."""
+        obj = json.loads(
+            display.format_json("rt1", {"when": datetime.date(2026, 5, 31)})
+        )
+        assert obj["when"] == "2026-05-31"
+
+    def test_format_json_obj_no_hostname_injection(self):
+        """format_json_obj emits the object as-is (no hostname key added)."""
+        obj = json.loads(display.format_json_obj({"model": "EX2300", "ok": True}))
+        assert obj == {"model": "EX2300", "ok": True}
+
+
+class TestRouteLogsToStderr:
+    """_route_logs_to_stderr moves stdout handlers, leaves others alone."""
+
+    def test_stdout_handler_moved_to_stderr(self):
+        root = logging.getLogger()
+        h = logging.StreamHandler(sys.stdout)
+        root.addHandler(h)
+        try:
+            cli._route_logs_to_stderr()
+            assert h.stream is sys.stderr
+        finally:
+            root.removeHandler(h)
+
+    def test_non_stdout_handler_untouched(self):
+        root = logging.getLogger()
+        sink = MagicMock()
+        h = logging.StreamHandler(sink)
+        root.addHandler(h)
+        try:
+            cli._route_logs_to_stderr()
+            assert h.stream is sink
+        finally:
+            root.removeHandler(h)
+
+
+class TestCmdJsonOutput:
+    """cmd_* honour --json and keep stdout machine-parseable."""
+
+    def test_cmd_version_emits_json(self, capsys, mock_args, mock_config):
+        mock_args.json = True
+        dev = MagicMock()
+        result = {
+            "hostname": "test-host",
+            "ok": True,
+            "model": "EX2300-24T",
+            "running": "22.4R3",
+        }
+        with (
+            patch.object(
+                cli.common, "connect", return_value={"ok": True, "dev": dev}
+            ),
+            patch.object(cli.upgrade, "show_version", return_value=result),
+        ):
+            rc = cli.cmd_version("test-host")
+        assert rc == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.splitlines() if ln.strip()]
+        assert len(lines) == 1
+        obj = json.loads(lines[0])
+        assert obj["hostname"] == "test-host"
+        assert obj["running"] == "22.4R3"
+
+    def test_connect_error_emits_json(self, capsys, mock_args, mock_config):
+        mock_args.json = True
+        with patch.object(
+            cli.common,
+            "connect",
+            return_value={
+                "ok": False,
+                "error": "ConnectTimeoutError",
+                "error_message": "timed out",
+            },
+        ):
+            rc = cli.cmd_version("test-host")
+        assert rc == 1
+        obj = json.loads(capsys.readouterr().out.strip())
+        assert obj == {
+            "hostname": "test-host",
+            "ok": False,
+            "phase": "connect",
+            "error": "ConnectTimeoutError",
+            "error_message": "timed out",
+        }
+
+    def test_worker_exception_emits_json_error(self, capsys, mock_args, mock_config):
+        mock_args.json = True
+        dev = MagicMock()
+        with (
+            patch.object(
+                cli.common, "connect", return_value={"ok": True, "dev": dev}
+            ),
+            patch.object(
+                cli.upgrade, "show_version", side_effect=RuntimeError("boom")
+            ),
+        ):
+            rc = cli.cmd_version("test-host")
+        assert rc == 1
+        obj = json.loads(capsys.readouterr().out.strip())
+        assert obj["ok"] is False
+        assert obj["error"] == "RuntimeError"
+        assert obj["error_message"] == "boom"
+
+    def test_config_json_stdout_stays_pure_json(self, capsys, mock_args, mock_config):
+        """The headline guarantee: even when load_config streams progress via
+        logger.info, --json keeps stdout 100% JSON by rerouting logs to stderr.
+        """
+        mock_args.json = True
+        mock_args.configfile = "commands.set"
+        # Attach a console handler to the SAME stdout capsys captures, so a
+        # regression (logs left on stdout) would corrupt the captured output.
+        root = logging.getLogger()
+        console = logging.StreamHandler(sys.stdout)
+        console.setLevel(logging.INFO)
+        root.addHandler(console)
+
+        dev = MagicMock()
+        mock_cu = MagicMock()
+        mock_cu.diff.return_value = "[edit]\n+  set system host-name test"
+        uptime_xml = MagicMock()
+        current_time = MagicMock()
+        current_time.text = "2026-05-31 12:00:00 JST"
+        uptime_xml.findtext.return_value = "2026-05-31 12:00:00 JST"
+        uptime_xml.find.return_value = current_time
+        dev.rpc.get_system_uptime_information.return_value = uptime_xml
+        try:
+            cli._route_logs_to_stderr()  # the fix under test
+            with (
+                patch.object(
+                    cli.common, "connect", return_value={"ok": True, "dev": dev}
+                ),
+                patch("junos_ops.upgrade.Config", return_value=mock_cu),
+                patch.object(
+                    common,
+                    "load_commands",
+                    return_value=["set system host-name test"],
+                ),
+            ):
+                rc = cli.cmd_config("test-host")
+        finally:
+            root.removeHandler(console)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        out_lines = [ln for ln in captured.out.splitlines() if ln.strip()]
+        # Every stdout line must be valid JSON — this is the machine-readable
+        # contract. If any logger.info leaked to stdout, json.loads raises.
+        assert out_lines, "expected at least one JSON line on stdout"
+        for ln in out_lines:
+            json.loads(ln)


### PR DESCRIPTION
## 概要

すべてのサブコマンドにグローバル `--json` フラグを追加し、機械可読な JSON 出力（JSONL）を提供する。

junos-ops は元々「dict を返す core + `format_*`/`print_*` の 2 層 display」というアーキテクチャで設計されており、core 関数はすでに plain dict を返す。`--json` はこの dict を `display.print_json` でそのまま 1 行 JSON にするだけ — 人間向け `format_*` 経路を選ばないだけの、設計に元々想定されていた「最後のピース」に当たる。

## 仕様

- ホストごとに **1 行 1 JSON オブジェクト（JSONL）**。`--workers N` の並列実行と自然に両立（top-level 配列は作らない。`jq -s` で slurp）
- **ログは stderr へ退避**（`_route_logs_to_stderr`）。`logging.ini` の consoleHandler も fallback basicConfig も stdout に出すため、`config` の `logger.info` 進捗等が JSON を汚すのを防ぐ。これが「stdout は純粋 JSON」契約の要
- **失敗ホストも 1 行出す**（`{"hostname": ..., "ok": false, "error", "error_message"}`）。JSONL consumer がホストの取りこぼしに気づけないのを防ぐ
- 起動時 fatal（設定読込失敗、対象ホスト 0 件）は stdout を汚さず **stderr へ診断**＋終了コードで通知
- `check --json` は各行に `"check": "local"`（model 単位）/ `"check": "host"`（ホスト単位）を付与

## テスト

`tests/test_json_output.py`（17 ケース）。headline は `test_config_json_stdout_stays_pure_json`（`load_config` が `logger.info` を流す状況で stdout 全行が `json.loads` 可能であることを検証）と、`_run()` 配線を `check --json --local` で駆動する回帰ロック。全体 335 passed。

## 既知の制限

- `cmd_facts --json` は `dict(dev.facts)` を `default=str` でシリアライズするため、PyEZ のネストオブジェクト（`version_info`、RE info 等）は構造ではなく文字列に潰れる（lossy）。クラッシュはしないが、facts の JSON は完全な構造化ではない。実デバイス無しのため当該経路は単体テスト未カバー

## 付随

- CLAUDE.md の陳腐化した記述（`cli.py` の `copy = upgrade.copy` 等の後方互換 alias — 実際にはすでに存在せず dispatch は `cmd_*` 経由）を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)