### PR TITLE
ci: bump release-please-action v4 to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # Use a fine-grained PAT so that tags and releases created by
           # release-please trigger downstream workflows. Tokens attributed


### PR DESCRIPTION
## 概要

`googleapis/release-please-action` を `v4` → `v5` に更新する。

## v5.0.0 の変更点（v4.4.1 からの差分）

- **唯一の破壊的変更は node24 アクションランタイムへの移行**（[#1188](https://github.com/googleapis/release-please-action/issues/1188)）。アクションの入力（`token` / `config-file` / `manifest-file`）に変更はなく、既存の `with:` ブロックはそのまま利用できる
- 同梱の release-please 本体も 17.3.0 → 17.6.0 にバンプ（バグ修正のみ）

## 互換性

`ubuntu-latest`（Ubuntu 24.04）は node24 アクションランタイムに対応済みのため、ランナー側の変更は不要。リスクは低い。

## テスト

- ワークフロー定義のバージョン文字列のみの変更（1 行）
- 実際の検証は次回 main への merge 時に release-please PR が正常に開くことで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)