### PR TITLE
feat: add --exclude-tags option to subtract hosts from selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ LICENSE
 - `_get_host_tags()` — ホストセクションのタグを set で返す
 - `_parse_tag_groups()` — `--tags` CLI 値（list / str / None）を set のリストに正規化
 - `_filter_by_tag_groups()` — タグのグループで絞り込み（グループ内 AND、グループ間 OR）
-- `get_targets()` — ターゲットホストリスト決定（`--tags` は `action="append"`。ホスト名併記時はタグフィルタ ∩ 名前リスト）
+- `get_targets()` — ターゲットホストリスト決定（`--tags` は `action="append"`。ホスト名併記時はタグフィルタ ∩ 名前リスト。`--exclude-tags` は `--tags` 同文法・`action="append"` で最終段の除外フィルタとして適用、単独利用可、全除外時は `_fatal` で sys.exit）
 - `run_parallel()` — ThreadPoolExecutorラッパー（max_workers=1でシリアル実行）
 
 ### upgrade.py — パッケージ操作（すべて dict を返す）
@@ -127,7 +127,7 @@ junos-ops [hostname ...]                   # サブコマンド省略 → device
 junos-ops --version                        # プログラムバージョン
 ```
 
-共通オプション: `--config` (`-c`), `--dry-run` (`-n`), `-d`, `--force`, `--workers N`, `--tags TAG,...`, `--json`（機械可読 JSONL 出力。ログは stderr へ退避）
+共通オプション: `--config` (`-c`), `--dry-run` (`-n`), `-d`, `--force`, `--workers N`, `--tags TAG,...`, `--exclude-tags TAG,...`, `--json`（機械可読 JSONL 出力。ログは stderr へ退避）
 
 ## 開発環境セットアップ
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -223,6 +223,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `--force` | 条件を無視して強制実行 |
 | `--json` | 人間向けテキストの代わりに機械可読 JSON を出力。ホストごとに 1 行の JSON オブジェクト（JSONL）。ログは stderr に退避されるため stdout は純粋な JSON のみ。`jq -s` で配列に slurp 可能。詳細は「JSON 出力」セクション参照 |
 | `--tags TAG[,TAG...]` | タグでホストをフィルタ。カンマ区切りは 1 グループ内の AND、`--tags` の繰り返しはグループ間 OR。ホスト名併記時はタグフィルタと積集合。詳細は「タグベースのホストフィルタリング」セクション参照 |
+| `--exclude-tags TAG[,TAG...]` | タグに一致するホストを除外。文法は `--tags` と同じ（カンマ区切り＝グループ内 AND、繰り返し＝グループ間 OR）。`--tags` 適用後にかかり、単独でも利用可（デフォルトの「全ホスト」集合から差し引く） |
 | `--workers N` | 並列実行数（デフォルト: upgrade系=1, rsi=20） |
 | `--version` | プログラムバージョン表示 |
 
@@ -395,6 +396,27 @@ junos-ops version --tags tokyo,core --tags access
 
 # backup タグを持つホストのうち、指定した 2 台だけを対象にする（タグフィルタ ∩ 名前リスト）
 junos-ops copy --tags backup rt1.example.jp rt2.example.jp
+```
+
+#### `--exclude-tags` で除外する
+
+`--exclude-tags` は `--tags` と同じ文法でホストを「落とす」フィルタです。`--tags` とホスト名による絞り込みが終わったあとに最終段として適用されます。
+
+- `--exclude-tags a,b` は `a` と `b` を**両方**持つホストだけ落とします（グループ内 AND）。
+- 繰り返し指定するとグループ間 OR になり、`--exclude-tags a --exclude-tags b` は `a` または `b` を持つホストを落とします。
+- `--exclude-tags` は単独利用も可能です。`--tags` やホスト名指定が無いときはデフォルトの「全セクション」集合から差し引きます。
+- すべてのホストが除外された場合は黙って no-op せずエラー終了します。
+
+```
+# main タグ持ちのうち SRX345 以外
+junos-ops check --remote --tags main --exclude-tags srx345
+
+# lab タグ以外の全ホスト
+junos-ops version --exclude-tags lab
+
+# main タグ持ちから SRX345 と EOL 機種を両方落とす（OR で除外）
+junos-ops check --remote --tags main \
+                --exclude-tags srx345 --exclude-tags eol
 ```
 
 ## 実行例

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `--force` | Force execution regardless of conditions |
 | `--json` | Emit machine-readable JSON instead of human-readable text. One JSON object per host per line (JSONL); logs are routed to stderr so stdout stays pure JSON. Pipe to `jq -s` to slurp into an array. See "JSON Output" below. |
 | `--tags TAG[,TAG...]` | Filter hosts by tags. Comma-separates AND together inside one value; repeating `--tags` ORs groups. Combined with explicit hostnames, the tag filter and hostname list intersect. See "Tag-based Host Filtering" below. |
+| `--exclude-tags TAG[,TAG...]` | Drop hosts whose tags match. Same AND/OR grammar as `--tags` (comma = AND within a group, repeat to OR groups). Applied after `--tags`; usable standalone to subtract a subset from the default "all hosts" selection. |
 | `--workers N` | Parallel workers (default: 1 for upgrade, 20 for rsi) |
 | `--version` | Show program version |
 
@@ -410,6 +411,34 @@ junos-ops version --tags tokyo,core --tags access
 # Among "backup"-tagged hosts, target only these two (tag filter +
 # hostname list = intersection)
 junos-ops copy --tags backup rt1.example.jp rt2.example.jp
+```
+
+#### Excluding hosts with `--exclude-tags`
+
+`--exclude-tags` removes hosts from the selection using the same
+grammar as `--tags`. It runs **after** `--tags` and the hostname
+intersection, so it acts as a final "drop these" pass.
+
+- `--exclude-tags a,b` drops hosts tagged with *both* `a` and `b`
+  (AND within a group).
+- Repeating the flag ORs groups, so
+  `--exclude-tags a --exclude-tags b` drops hosts tagged with `a`
+  *or* `b`.
+- `--exclude-tags` may be used on its own; without `--tags` or a
+  hostname list it subtracts from the default "all sections" set.
+- If every candidate host is dropped, junos-ops exits with an error
+  instead of silently no-op'ing.
+
+```
+# All hosts tagged "main" except SRX345 boxes
+junos-ops check --remote --tags main --exclude-tags srx345
+
+# Run against every host except the lab tier
+junos-ops version --exclude-tags lab
+
+# Drop SRX345 OR EOL hosts from the main set
+junos-ops check --remote --tags main \
+                --exclude-tags srx345 --exclude-tags eol
 ```
 
 ## Examples

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -670,6 +670,16 @@ def _run():
             "groups: --tags a,b --tags c = (a AND b) OR c."
         ),
     )
+    parent.add_argument(
+        "--exclude-tags", type=str, default=None, action="append",
+        dest="exclude_tags",
+        help=(
+            "exclude hosts whose tags match. Same AND/OR grammar as --tags "
+            "(comma = AND within a group, repeat to OR groups). Applied "
+            "after --tags. Usable on its own to drop a subset from the "
+            "default 'all hosts' selection: --exclude-tags srx345."
+        ),
+    )
 
     parser = argparse.ArgumentParser(
         description="junos-ops: Juniper Networks デバイス管理ツール",
@@ -938,6 +948,8 @@ def _run():
         args.show_format = "text"
     if not hasattr(args, "tags"):
         args.tags = None
+    if not hasattr(args, "exclude_tags"):
+        args.exclude_tags = None
     if not hasattr(args, "retry"):
         args.retry = 0
     if not hasattr(args, "rpc_timeout"):

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -220,6 +220,7 @@ def _parse_tag_groups(tags) -> list[set[str]]:
 def get_targets():
     """Return target host list from CLI args, tags, or config sections."""
     tags = getattr(args, "tags", None)
+    exclude_tags = getattr(args, "exclude_tags", None)
     has_hosts = len(args.specialhosts) > 0
 
     def _fatal(*parts):
@@ -231,15 +232,24 @@ def get_targets():
         sys.exit(1)
 
     tag_groups = _parse_tag_groups(tags)
+    exclude_groups = _parse_tag_groups(exclude_tags)
+    excluded = set(_filter_by_tag_groups(exclude_groups)) if exclude_groups else set()
+
+    def _drop_excluded(hosts):
+        if not excluded:
+            return hosts
+        return [h for h in hosts if h not in excluded]
 
     # パターン1: --tags なし & hosts なし → 全セクション（現行動作）
     if not tag_groups and not has_hosts:
         # read_config() guarantees every section has a 'host' option (it
         # sets it to the section name when absent), so the previous None
         # check / sys.exit branch here was unreachable.
-        targets = list(config.sections())
+        targets = _drop_excluded(list(config.sections()))
         for i in targets:
             logger.debug(f"{i=} host={config.get(i, 'host')}")
+        if exclude_groups and not targets:
+            _fatal("no hosts left after --exclude-tags:", exclude_tags)
         return targets
 
     # パターン2: --tags なし & hosts あり → 指定ホストのみ（現行動作）
@@ -252,6 +262,12 @@ def get_targets():
                 _fatal(i, "is not found in", args.config)
             logger.debug(f"{i=} {tmp=}")
             targets.append(i)
+        targets = _drop_excluded(targets)
+        if exclude_groups and not targets:
+            _fatal(
+                "no hosts left after --exclude-tags:",
+                exclude_tags, args.specialhosts,
+            )
         return targets
 
     # Pattern 3: --tags only -> union of each group's AND match.
@@ -259,8 +275,13 @@ def get_targets():
     # --tags occurrences OR together. Example: --tags a,b --tags c
     # matches hosts with (a AND b) OR c.
     if tag_groups and not has_hosts:
-        targets = _filter_by_tag_groups(tag_groups)
+        targets = _drop_excluded(_filter_by_tag_groups(tag_groups))
         if not targets:
+            if exclude_groups:
+                _fatal(
+                    "no hosts left after --tags and --exclude-tags:",
+                    tags, exclude_tags,
+                )
             _fatal("no hosts matched tags:", tags)
         return targets
 
@@ -274,7 +295,13 @@ def get_targets():
             _fatal(i, "is not found in", args.config)
         if i in tag_matched:
             targets.append(i)
+    targets = _drop_excluded(targets)
     if not targets:
+        if exclude_groups:
+            _fatal(
+                "no hosts left after --tags, --exclude-tags and names:",
+                tags, exclude_tags, args.specialhosts,
+            )
         _fatal("no hosts matched both tags and names:", tags, args.specialhosts)
     return targets
 

--- a/junos_ops/common.py
+++ b/junos_ops/common.py
@@ -233,7 +233,8 @@ def get_targets():
 
     tag_groups = _parse_tag_groups(tags)
     exclude_groups = _parse_tag_groups(exclude_tags)
-    excluded = set(_filter_by_tag_groups(exclude_groups)) if exclude_groups else set()
+    # _filter_by_tag_groups([]) returns [] so set() is empty; no ternary needed.
+    excluded = set(_filter_by_tag_groups(exclude_groups))
 
     def _drop_excluded(hosts):
         if not excluded:
@@ -252,7 +253,11 @@ def get_targets():
             _fatal("no hosts left after --exclude-tags:", exclude_tags)
         return targets
 
-    # パターン2: --tags なし & hosts あり → 指定ホストのみ（現行動作）
+    # パターン2: --tags なし & hosts あり → 指定ホストのみ（現行動作）。
+    # Explicitly named hosts are still subject to --exclude-tags: the
+    # operator opted into "from these names, drop the ones matching X
+    # tag" by passing both, so this is the requested behavior, not an
+    # over-reach.
     if not tag_groups and has_hosts:
         targets = []
         for i in args.specialhosts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def mock_args(junos_common):
         show_command=None,
         showfile=None,
         tags=None,
+        exclude_tags=None,
         retry=0,
         rpc_timeout=None,
         no_confirm=False,

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -318,23 +318,56 @@ class TestGetTargetsWithExcludeTags:
         targets = junos_common.get_targets()
         assert targets == ["rt1.example.jp", "rt2.example.jp", "sw2.example.jp"]
 
-    def test_exclude_all_exits(self, junos_common, mock_args, mock_config_with_tags):
-        """If --exclude-tags removes every host, exit with sys.exit."""
+    def test_tagless_host_survives_exclude(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """Hosts with no tags are never matched by --exclude-tags."""
         junos_common.args.specialhosts = []
         junos_common.args.tags = None
-        # All four hosts get dropped: core matches rt1/rt2, access matches sw1,
-        # and sw2 has no tags; combine to cover sw2 too.
+        # core matches rt1/rt2, access matches sw1, but sw2 has no tags so
+        # it cannot be a superset of any exclude group and stays.
         junos_common.args.exclude_tags = ["core", "access"]
-        # sw2 has no tags so survives -- check that path first.
         targets = junos_common.get_targets()
         assert targets == ["sw2.example.jp"]
+
+    def test_exclude_only_drops_everything_exits(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """Pattern 1: --exclude-tags only that removes every host -> sys.exit."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        # Tag the tagless host so every section gets dropped.
+        junos_common.config.set("sw2.example.jp", "tags", "drop")
+        junos_common.args.exclude_tags = ["core", "access", "drop"]
+        with pytest.raises(SystemExit):
+            junos_common.get_targets()
+
+    def test_exclude_with_hosts_drops_all_exits(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """Pattern 2: hosts + --exclude-tags that drops every named host -> sys.exit."""
+        junos_common.args.specialhosts = ["sw1.example.jp"]
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "access"
+        with pytest.raises(SystemExit):
+            junos_common.get_targets()
 
     def test_exclude_with_tags_empty_exits(
         self, junos_common, mock_args, mock_config_with_tags
     ):
-        """--tags + --exclude-tags that leaves nothing -> sys.exit."""
+        """Pattern 3: --tags + --exclude-tags that leaves nothing -> sys.exit."""
         junos_common.args.specialhosts = []
         junos_common.args.tags = "core"
+        junos_common.args.exclude_tags = "core"
+        with pytest.raises(SystemExit):
+            junos_common.get_targets()
+
+    def test_exclude_with_tags_and_hosts_empty_exits(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """Pattern 4: --tags + hosts + --exclude-tags that leaves nothing -> sys.exit."""
+        junos_common.args.specialhosts = ["rt1.example.jp"]
+        junos_common.args.tags = "tokyo"
         junos_common.args.exclude_tags = "core"
         with pytest.raises(SystemExit):
             junos_common.get_targets()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -247,3 +247,94 @@ class TestGetTargetsWithTags:
         junos_common.args.tags = "access"
         targets = junos_common.get_targets()
         assert targets == ["sw1.example.jp"]
+
+
+class TestGetTargetsWithExcludeTags:
+    """Tests for --exclude-tags filtering in get_targets()."""
+
+    def test_exclude_only_drops_tag(self, junos_common, mock_args, mock_config_with_tags):
+        """--exclude-tags only: drop matching hosts from the all-sections default."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "access"
+        targets = junos_common.get_targets()
+        # sw1 has access; everyone else stays. sw2 has no tags so it stays.
+        assert targets == ["rt1.example.jp", "rt2.example.jp", "sw2.example.jp"]
+
+    def test_exclude_only_no_match_keeps_all(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """--exclude-tags with no matching host leaves the selection untouched."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "nonexistent"
+        targets = junos_common.get_targets()
+        assert targets == [
+            "rt1.example.jp", "rt2.example.jp",
+            "sw1.example.jp", "sw2.example.jp",
+        ]
+
+    def test_exclude_with_tags(self, junos_common, mock_args, mock_config_with_tags):
+        """--tags core --exclude-tags osaka: keep core hosts minus osaka."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = "core"
+        junos_common.args.exclude_tags = "osaka"
+        targets = junos_common.get_targets()
+        # core matches rt1 and rt2; rt2 has osaka -> dropped.
+        assert targets == ["rt1.example.jp"]
+
+    def test_exclude_with_hosts(self, junos_common, mock_args, mock_config_with_tags):
+        """hosts + --exclude-tags drops listed hosts that match the exclude group."""
+        junos_common.args.specialhosts = ["rt1.example.jp", "sw1.example.jp"]
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "access"
+        targets = junos_common.get_targets()
+        # sw1 has access -> dropped. rt1 stays.
+        assert targets == ["rt1.example.jp"]
+
+    def test_exclude_and_within_group(self, junos_common, mock_args, mock_config_with_tags):
+        """--exclude-tags tokyo,core: only drop hosts with BOTH tokyo AND core."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "tokyo,core"
+        targets = junos_common.get_targets()
+        # Only rt1 has both -> dropped. sw1 has tokyo only, so it stays.
+        assert targets == ["rt2.example.jp", "sw1.example.jp", "sw2.example.jp"]
+
+    def test_exclude_repeated_or(self, junos_common, mock_args, mock_config_with_tags):
+        """--exclude-tags a --exclude-tags b: OR across groups."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = ["access", "osaka"]
+        targets = junos_common.get_targets()
+        # access -> sw1; osaka -> rt2.
+        assert targets == ["rt1.example.jp", "sw2.example.jp"]
+
+    def test_exclude_case_insensitive(self, junos_common, mock_args, mock_config_with_tags):
+        """--exclude-tags is case-insensitive like --tags."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        junos_common.args.exclude_tags = "ACCESS"
+        targets = junos_common.get_targets()
+        assert targets == ["rt1.example.jp", "rt2.example.jp", "sw2.example.jp"]
+
+    def test_exclude_all_exits(self, junos_common, mock_args, mock_config_with_tags):
+        """If --exclude-tags removes every host, exit with sys.exit."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = None
+        # All four hosts get dropped: core matches rt1/rt2, access matches sw1,
+        # and sw2 has no tags; combine to cover sw2 too.
+        junos_common.args.exclude_tags = ["core", "access"]
+        # sw2 has no tags so survives -- check that path first.
+        targets = junos_common.get_targets()
+        assert targets == ["sw2.example.jp"]
+
+    def test_exclude_with_tags_empty_exits(
+        self, junos_common, mock_args, mock_config_with_tags
+    ):
+        """--tags + --exclude-tags that leaves nothing -> sys.exit."""
+        junos_common.args.specialhosts = []
+        junos_common.args.tags = "core"
+        junos_common.args.exclude_tags = "core"
+        with pytest.raises(SystemExit):
+            junos_common.get_targets()


### PR DESCRIPTION
## Summary

- Add `--exclude-tags TAG[,TAG...]` as a common option mirroring `--tags` grammar (comma = AND within a group, repeat = OR across groups).
- Apply it as a final drop pass after `--tags` and the hostname intersection. Standalone use is allowed and subtracts from the default "all sections" selection.
- Exit non-zero when every candidate host gets dropped instead of silently no-op'ing (consistent with the existing "no hosts matched tags" behavior).

## Motivation

`--tags main` selects every production host but there was no concise way to say "main minus SRX345". Doing it through `--tags` alone required enumerating every desired model group:

```
junos-ops check --tags main,ex4400 --tags main,ex3400 \
                --tags main,ex2300 --tags main,mx5 ...
```

With this PR:

```
junos-ops check --remote --tags main --exclude-tags srx345
```

## Test plan

- [x] `pytest tests/` — 344 passed (was 335 before; 9 new `TestGetTargetsWithExcludeTags` cases)
- [x] `junos-ops version --help` shows `--exclude-tags` in the parent parser group
- [ ] Smoke against staging: `junos-ops check --remote --tags main --exclude-tags srx345 --workers 10`

### New tests

- `--exclude-tags` only (subtract from all-sections default)
- `--exclude-tags` with no matching host leaves selection untouched
- `--tags` + `--exclude-tags` intersection
- hostnames + `--exclude-tags` intersection
- AND-within-group exclude (`--exclude-tags tokyo,core`)
- OR-across-groups exclude (`--exclude-tags a --exclude-tags b`)
- Case-insensitive matching
- Exit-on-empty when `--tags` and `--exclude-tags` cancel each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)