### PR TITLE
feat(check): filter --local inventory by --tags / --exclude-tags / hostnames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ LICENSE
 - `main()` — argparse サブコマンド定義、ディスパッチ
 - `cmd_upgrade()`, `cmd_copy()`, `cmd_install()`, `cmd_rollback()`, `cmd_version()`, `cmd_reboot()`, `cmd_ls()`, `cmd_show()`, `cmd_config()`, `cmd_facts()` — サブコマンド用エントリ関数（connect → header → core(dict) → display）
 - `_check_host(hostname)` — `check` サブコマンド用ワーカー。int ではなく dict を返し、`main()` で結果を集約して `display.print_check_table` にテーブル出力。モデル解決順: `--model` > `config.ini [host].model` > `dev.facts["model"]`
+- `_check_local_inventory()` — `check --local` 用ワーカー。デフォルトは config.ini DEFAULT の `<model>.file` 全列挙。`--tags` / `--exclude-tags` / hostnames のいずれかが指定されると filtered mode に切り替わり、`common.get_targets()` で選んだホストの `[host].model` を集めたモデル集合だけを対象に絞る（`--model` とは積集合）。`[host].model` が無いホストは NETCONF 無しでは解決不能なため `status="unmapped"` の行を 1 件ずつ追加し、rc には影響させない
 - `_open_connection()` — NETCONF 接続＋エラー時の display 出力ヘルパー（`--json` 時は connect エラーを JSON で出す）
 - `--json` グローバルオプション: 各 `cmd_*` は `_emit_result(hostname, result, formatter)` で「`--json` なら `display.print_json`、通常は `display.print_host_block(formatter(result))`」を分岐。失敗ホストは `_emit_exception` が `{"ok": false, "error", "error_message"}` の JSON 行を出す（JSONL consumer が行欠落で気づけないのを防ぐ）。出力は host ごと 1 行の JSONL（`run_parallel` で並列のため top-level 配列は作らない。`jq -s` で slurp）
 - `_route_logs_to_stderr()` — `--json` 時に root logger の stdout 向け StreamHandler を stderr へ移す。`logging.ini` の consoleHandler も fallback の basicConfig も stdout に出力するため、これをやらないと `load_config` の `logger.info` 進捗等が JSON を汚す。`_run()` で `common.args` 設定直後に呼ぶ

--- a/README.ja.md
+++ b/README.ja.md
@@ -471,6 +471,13 @@ mx5-t            jinstall-ppc-21.2R3-S8.5-signed.tgz                         mis
 
 `--model M` で特定モデルだけに絞り込むことも可能です。
 
+デフォルトの `--local` はホスト名や `--tags` を無視しますが、`--tags` / `--exclude-tags` / 明示ホスト名のいずれかが指定された場合は **フィルタ付きインベントリモード** に切り替わります。CLI 共通のセレクタで対象ホストを絞り込み、各ホストの `[host].model` キーを集めてモデル集合を作り、その集合に属するモデルの recipe だけを出力します。`--model` と --tags/ホストフィルタは積集合で適用されます。`config.ini` に `model = ...` が無いホストは NETCONF 無しでは解決できないため、行頭に `unmapped` として並びます（`[host].model` を追記するか、`--connect` / `--remote` に切り替えてください）。
+
+```
+# main タグ付きホストが使っているモデルだけを inventory チェック
+% junos-ops check --local --tags main
+```
+
 `--connect` / `--remote`（および `--all`）は **ホスト単位** で、指定されたホスト（または `config.ini` 内の全ホスト、`--tags` でフィルタ可能）に対して動作します。`--remote` は `copy` 完了後・`install` 前の「SCP が最後まで落ちたか」確認としても使えます:
 
 ```

--- a/README.md
+++ b/README.md
@@ -493,6 +493,13 @@ mx5-t            jinstall-ppc-21.2R3-S8.5-signed.tgz                         mis
 
 Use `--model M` to restrict the inventory to a single model.
 
+By default `--local` ignores hostnames and `--tags`. When you do pass `--tags`, `--exclude-tags`, or explicit hostnames, `--local` switches into **filtered inventory** mode: the selected hosts are resolved via the same selector as the rest of the CLI, each host's `[host].model` key is collected into a set, and only inventory rows for those models are emitted. `--model` and the tag/host filter intersect. Hosts without a `model = ...` line in `config.ini` cannot be mapped without NETCONF, so they show up as `unmapped` rows reminding you to either add the key or fall back to `--connect` / `--remote`.
+
+```
+# Inventory limited to the models actually used by "main"-tagged hosts
+% junos-ops check --local --tags main
+```
+
 `--connect` / `--remote` (and `--all`) are **per-host** and use the specified hostnames (or every host in `config.ini`, optionally filtered by `--tags`). `--remote` doubles as a "did the SCP copy fully land" check between `copy` and `install`:
 
 ```

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -560,19 +560,74 @@ def _check_host(hostname) -> dict:
 def _check_local_inventory() -> list[dict]:
     """Inventory-mode ``check --local``: iterate model→file map in ``config.ini``.
 
-    Ignores hostnames entirely — the local firmware map is an attribute
-    of the staging server, not the devices. Verifies each model's
-    ``<model>.file`` against its ``<model>.hash``, filtered by
-    ``--model`` if supplied. Uses ``"DEFAULT"`` as the config section
-    so DEFAULT-level ``lpath`` / ``hashalgo`` apply.
+    Default behavior (no ``--tags`` / ``--exclude-tags`` / hostnames):
+    walk every ``<model>.file`` in DEFAULT — the local firmware map is
+    an attribute of the staging server, not the devices. Verifies each
+    model's ``<model>.file`` against its ``<model>.hash``, filtered by
+    ``--model`` if supplied.
+
+    Filter mode (``--tags`` / ``--exclude-tags`` / hostnames given):
+    delegate host selection to :func:`common.get_targets`, then resolve
+    each selected host's ``[host].model`` option (lowercased) into a
+    set of models. Only models in that set are emitted. Hosts without
+    a configured ``model`` cannot be mapped without NETCONF, so they
+    are reported via an inventory row with ``status="unmapped"`` (one
+    row per host) instead of silently dropped — the operator can
+    decide whether to add a ``model = ...`` line or fall through to
+    ``--connect``/``--remote``.
+
+    ``--model`` and the tag/hostname filter intersect: only models
+    present in both shortlists are emitted.
+
+    Uses ``"DEFAULT"`` as the config section so DEFAULT-level
+    ``lpath`` / ``hashalgo`` apply.
     """
     filter_model = getattr(common.args, "check_model", None)
-    if filter_model:
-        models = [filter_model]
-    else:
-        models = upgrade.iter_configured_models()
+
+    tags = getattr(common.args, "tags", None)
+    exclude_tags = getattr(common.args, "exclude_tags", None)
+    has_hosts = len(common.args.specialhosts) > 0
+    use_host_filter = bool(tags or exclude_tags or has_hosts)
 
     rows: list[dict] = []
+    if use_host_filter:
+        targets = common.get_targets()
+        host_models: set[str] = set()
+        unmapped: list[str] = []
+        for host in targets:
+            model = common.config.get(host, "model", fallback="").strip().lower()
+            if model:
+                host_models.add(model)
+            else:
+                unmapped.append(host)
+
+        if filter_model:
+            host_models &= {filter_model.lower()}
+
+        models = sorted(host_models)
+        for host in unmapped:
+            rows.append({
+                "model": None,
+                "file": None,
+                "local_file": None,
+                "status": "unmapped",
+                "cached": False,
+                "actual_hash": None,
+                "expected_hash": None,
+                "message": (
+                    f"host {host}: no [{host}].model in config.ini; "
+                    "cannot resolve firmware without NETCONF "
+                    "(use --connect/--remote, or add a model = ... line)"
+                ),
+                "error": None,
+                "hostname": host,
+            })
+    else:
+        if filter_model:
+            models = [filter_model]
+        else:
+            models = upgrade.iter_configured_models()
+
     for model in models:
         try:
             result = upgrade.check_local_package_by_model("DEFAULT", model)
@@ -1039,6 +1094,9 @@ def _run():
             else:
                 display.print_check_local_inventory(inventory)
             for row in inventory:
+                # ``unmapped`` is not a firmware-staging failure; it is
+                # a config gap surfaced for the operator. Don't fail rc
+                # for it — only real bad/missing/error rows escalate.
                 if row.get("status") in ("bad", "missing", "error"):
                     rc = 1
 

--- a/junos_ops/display.py
+++ b/junos_ops/display.py
@@ -683,6 +683,13 @@ def format_check_local_inventory(rows: list[dict]) -> str:
         status = r.get("status", "-")
         if status == "ok" and r.get("cached"):
             status = "ok(cached)"
+        # ``unmapped`` rows come from host-filter mode when a selected
+        # host has no ``[host].model``; show the hostname in place of
+        # the model column so the table stays self-explanatory.
+        if status == "unmapped":
+            label = f"({r.get('hostname')})" if r.get("hostname") else "-"
+            body.append([label, "-", "unmapped"])
+            continue
         body.append([
             r.get("model") or "-",
             r.get("file") or "-",
@@ -723,6 +730,9 @@ def format_check_local_inventory(rows: list[dict]) -> str:
         if r.get("status") in ("bad", "error"):
             msg = (r.get("message") or "").lstrip()
             detail_lines.append(f"  {r.get('model')}: {msg}")
+        elif r.get("status") == "unmapped":
+            msg = (r.get("message") or "").lstrip()
+            detail_lines.append(f"  {r.get('hostname')}: {msg}")
     if detail_lines:
         lines.append("")
         lines.extend(detail_lines)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -14,6 +14,7 @@ Covers three surfaces:
 """
 
 import argparse
+import configparser
 import hashlib
 import os
 import tempfile
@@ -102,8 +103,10 @@ def _make_check_args(**overrides):
         debug=False,
         dry_run=False,
         force=False,
+        json=False,
         config="config.ini",
         tags=None,
+        exclude_tags=None,
         workers=1,
         specialhosts=[],
         check_connect=False,
@@ -279,6 +282,146 @@ class TestCheckLocalInventory:
             rows = cli._check_local_inventory()
         mock_chk.assert_called_once_with("DEFAULT", "EX2300-24T")
         assert len(rows) == 1
+
+
+def _make_inventory_config():
+    """Build a config with model-tagged hosts for inventory-filter tests."""
+    cfg = configparser.ConfigParser(allow_no_value=True)
+    cfg.read_dict(
+        {
+            "DEFAULT": {
+                "id": "u", "pw": "p", "sshkey": "k",
+                "port": "830", "hashalgo": "md5", "rpath": "/var/tmp",
+                "ex2300-24t.file": "junos-arm-32.tgz",
+                "ex2300-24t.hash": "h1",
+                "ex3400-24t.file": "junos-arm-32-ex3400.tgz",
+                "ex3400-24t.hash": "h2",
+                "srx345.file": "junos-srxsme.tgz",
+                "srx345.hash": "h3",
+            },
+            "rt-ex2300": {
+                "host": "rt-ex2300", "tags": "main", "model": "EX2300-24T",
+            },
+            "rt-ex3400": {
+                "host": "rt-ex3400", "tags": "main", "model": "EX3400-24T",
+            },
+            "rt-srx345": {
+                "host": "rt-srx345", "tags": "main", "model": "SRX345",
+            },
+            "rt-lab": {
+                "host": "rt-lab", "tags": "lab", "model": "EX2300-24T",
+            },
+            "rt-no-model": {"host": "rt-no-model", "tags": "main"},
+        }
+    )
+    return cfg
+
+
+class TestCheckLocalInventoryHostFilter:
+    """check --local in filter mode (--tags / --exclude-tags / hostnames)."""
+
+    def _patched_check(self):
+        return patch.object(
+            junos_upgrade_mod,
+            "check_local_package_by_model",
+            side_effect=lambda h, m: {
+                "file": f"pkg-{m}.tgz",
+                "local_file": f"/fw/pkg-{m}.tgz",
+                "status": "ok",
+                "cached": False,
+                "actual_hash": "x",
+                "expected_hash": "x",
+                "message": "",
+                "error": None,
+            },
+        )
+
+    def test_tags_filter_restricts_to_host_models(self, junos_common):
+        """--tags main: inventory limited to models used by main hosts."""
+        common.config = _make_inventory_config()
+        common.args = _make_check_args(check_local=True, tags="main")
+        with self._patched_check() as mock_chk:
+            rows = cli._check_local_inventory()
+        models = [c.args[1] for c in mock_chk.call_args_list]
+        # main hosts: rt-ex2300, rt-ex3400, rt-srx345, rt-no-model.
+        # rt-no-model has no [host].model -> unmapped row, model dropped.
+        assert sorted(models) == ["ex2300-24t", "ex3400-24t", "srx345"]
+        unmapped = [r for r in rows if r["status"] == "unmapped"]
+        assert len(unmapped) == 1
+        assert unmapped[0]["hostname"] == "rt-no-model"
+
+    def test_tags_excludes_drops_model(self, junos_common):
+        """--tags main --exclude-tags srx345 by host name? use tag-based exclude."""
+        common.config = _make_inventory_config()
+        # Tag-based exclude: tag srx host so we can drop it via exclude-tags.
+        common.config.set("rt-srx345", "tags", "main, drop")
+        common.args = _make_check_args(
+            check_local=True, tags="main", exclude_tags="drop",
+        )
+        with self._patched_check() as mock_chk:
+            cli._check_local_inventory()
+        models = [c.args[1] for c in mock_chk.call_args_list]
+        assert "srx345" not in models
+        assert sorted(models) == ["ex2300-24t", "ex3400-24t"]
+
+    def test_hostnames_filter(self, junos_common):
+        """Explicit hostnames also narrow the inventory."""
+        common.config = _make_inventory_config()
+        common.args = _make_check_args(
+            check_local=True, specialhosts=["rt-ex2300"],
+        )
+        with self._patched_check() as mock_chk:
+            cli._check_local_inventory()
+        models = [c.args[1] for c in mock_chk.call_args_list]
+        assert models == ["ex2300-24t"]
+
+    def test_model_and_tag_intersect(self, junos_common):
+        """--model X --tags main: intersection (only if X is in main hosts)."""
+        common.config = _make_inventory_config()
+        common.args = _make_check_args(
+            check_local=True, tags="main", check_model="EX2300-24T",
+        )
+        with self._patched_check() as mock_chk:
+            cli._check_local_inventory()
+        models = [c.args[1] for c in mock_chk.call_args_list]
+        assert models == ["ex2300-24t"]
+
+    def test_model_filter_outside_tag_set_is_empty(self, junos_common):
+        """--model M not in the host-filtered set yields zero rows (no error)."""
+        common.config = _make_inventory_config()
+        # Only lab has rt-lab (ex2300). Ask for SRX345 -> empty intersection.
+        common.args = _make_check_args(
+            check_local=True, tags="lab", check_model="SRX345",
+        )
+        with self._patched_check() as mock_chk:
+            rows = cli._check_local_inventory()
+        assert mock_chk.call_count == 0
+        # No model rows; lab host has model so no unmapped either.
+        assert rows == []
+
+    def test_unmapped_host_emits_row(self, junos_common):
+        """Selected host without [host].model surfaces an unmapped inventory row."""
+        common.config = _make_inventory_config()
+        common.args = _make_check_args(
+            check_local=True, specialhosts=["rt-no-model"],
+        )
+        with self._patched_check():
+            rows = cli._check_local_inventory()
+        # No model resolvable -> only the unmapped row.
+        assert len(rows) == 1
+        assert rows[0]["status"] == "unmapped"
+        assert rows[0]["hostname"] == "rt-no-model"
+
+    def test_default_mode_unchanged(self, junos_common):
+        """No filter: existing behaviour (every <model>.file in DEFAULT)."""
+        common.config = _make_inventory_config()
+        common.args = _make_check_args(check_local=True)
+        with self._patched_check() as mock_chk:
+            cli._check_local_inventory()
+        models = sorted(c.args[1] for c in mock_chk.call_args_list)
+        # All three configured models, including srx345 which no main host
+        # is wearing in the filtered scenarios above.
+        assert models == ["ex2300-24t", "ex3400-24t", "srx345"]
 
     def test_format_inventory_with_lpath_header(self):
         """Shared lpath is shown once above the table, not repeated per row."""


### PR DESCRIPTION
**Stacked on #99** — base is `feat/exclude-tags`. Will be retargeted to `main` once #99 lands.

## Summary

- `check --local` switches into a **filtered inventory mode** when `--tags`, `--exclude-tags`, or explicit hostnames are given.
- Host selection is delegated to `common.get_targets()` (same selector as the rest of the CLI, so the `--exclude-tags` work in #99 composes naturally).
- Each selected host's `[host].model` is collected into a lowercase set; the inventory walks only those models. `--model` and the host-derived set intersect.
- Hosts without `[host].model` cannot be mapped without NETCONF, so they surface as `status="unmapped"` rows (one per host) instead of being silently dropped. `unmapped` does not escalate `rc` — it is a config gap, not a staging failure.
- Default behavior (no filter flags) is untouched — every `<model>.file` in DEFAULT is still walked.

## Motivation

The trigger was a real run:

```
$ junos-ops check --local --tags main
lpath: /home/.../junos-ops
model           file                                          status
--------------  --------------------------------------------  ----------
ex2300-24t      junos-arm-32-23.4R2-S8.7.tgz                  ok
ex3400-24t      junos-arm-32-23.4R2-S8.7.tgz                  ok(cached)
ex4300-32f      jinstall-ex-4300-21.4R3-S12.2-signed.tgz      ok
...
srx345          junos-srxsme-23.4R2-S8.7.tgz                  ok
```

`--tags main` was silently ignored because `--local` was inventory-only. Operators expected "only the models actually used by my main-tagged hosts" — which is exactly what this PR delivers, still without touching NETCONF.

## Test plan

- [x] `pytest tests/` — 351 passed (was 344; +7 new `TestCheckLocalInventoryHostFilter` cases, regression guard for the unfiltered default path)
- [x] Help text unchanged — `--local` still documented as inventory mode, filter behavior is in README
- [ ] Smoke against staging: `junos-ops check --local --tags main` matches the model subset; `--local --tags main --exclude-tags drop` excludes; `--local rt-no-model` surfaces an `unmapped` row

### New tests

- `--tags main` restricts inventory to host-derived models, untagged host becomes an `unmapped` row
- `--tags main --exclude-tags drop` drops the right model
- Explicit hostname filter narrows the inventory
- `--model X --tags main` intersection
- `--model M` outside the tag set yields zero rows (no error)
- Single hostname without `[host].model` yields only the `unmapped` row
- Default (no filter) still walks every configured model

🤖 Generated with [Claude Code](https://claude.com/claude-code)