### PR TITLE
fix(check): normalize --model casing and align checksum terminology

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ Juniper/JUNOS デバイスの運用を NETCONF 経由で自動化する Python C
 - ロールバック対応（MX/EX/SRX モデル別処理）
 - スケジュールリブート（ファームウェアインストール後の config 変更を自動検出し、必要なら再インストール）
 - RSI（request support information）/ SCF（show configuration | display set）の並列収集
-- Pre-flight `check` サブコマンド: NETCONF 疎通・ローカル firmware ハッシュ（デバイス接続不要）・リモート firmware ハッシュを 1 コマンドで統合表示
+- Pre-flight `check` サブコマンド: NETCONF 疎通・ローカル firmware チェックサム（デバイス接続不要）・リモート firmware チェックサムを 1 コマンドで統合表示
 - 任意の CLI コマンドを複数ホストで実行（`show` サブコマンド、`RpcTimeoutError` 自動リトライ対応）
 - `config` での設定投入（commit confirmed + コミット後ヘルスチェック: ping / `uptime` NETCONF プローブ / 任意の CLI コマンド）
 - Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.md#日本語版)）
@@ -207,7 +207,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `reboot --at YYMMDDHHMM` | 指定日時にリブートをスケジュール |
 | `ls [-l]` | リモートパスのファイル一覧 |
 | `show COMMAND [--retry N]` / `show -f FILE` | 任意の CLI コマンド（またはコマンドファイル）を複数ホストで実行 |
-| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight チェック: NETCONF 疎通・ローカル/リモート firmware ハッシュ |
+| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight チェック: NETCONF 疎通・ローカル/リモート firmware チェックサム |
 | `config -f FILE` | set コマンドファイルを適用（`--confirm` / `--timeout` / `--no-confirm` / `--no-commit` / `--health-check` / `--no-health-check` の詳細は [docs/config.md](docs/config.md) を参照） |
 | `rsi` | RSI/SCF を並列収集 |
 | （なし） | デバイスファクト（device facts）を表示 |
@@ -453,7 +453,7 @@ rt1.example.jp: software validate package-result: 0
 
 ### check（Pre-flight 検証）
 
-NETCONF 疎通、ローカル/リモートの firmware ハッシュを 1 コマンドで一括検証します。1 件でも失敗すると終了コードが非ゼロになります。フラグ未指定時のデフォルトは `--connect` のみ。
+NETCONF 疎通、ローカル/リモートの firmware チェックサムを 1 コマンドで一括検証します。1 件でも失敗すると終了コードが非ゼロになります。フラグ未指定時のデフォルトは `--connect` のみ。
 
 `--local` は **インベントリモード** で、ホスト名は無視されます。`config.ini` に記載された `<model>.file` / `<model>.hash` のペアを列挙してステージングサーバー上のファイルを検証するので、NETCONF 接続は一切不要です:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Python CLI to automate Juniper/JUNOS operations over NETCONF: model-aware upgr
 - Rollback support (model-specific handling for MX/EX/SRX)
 - Scheduled reboot with automatic config-drift detection and re-install
 - Parallel RSI (request support information) / SCF (show configuration | display set) collection
-- Pre-flight `check` subcommand: NETCONF reachability, local firmware hash (device-less), and remote firmware hash in one unified table
+- Pre-flight `check` subcommand: NETCONF reachability, local firmware checksum (device-less), and remote firmware checksum in one unified table
 - Arbitrary CLI command execution across hosts (`show`) with `RpcTimeoutError` retry
 - Configuration push with `commit confirmed` safety and post-commit health checks (ping, `uptime` NETCONF probe, or any CLI command)
 - Jinja2 template support for per-host configuration generation ([details](docs/template.md))
@@ -207,7 +207,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `reboot --at YYMMDDHHMM` | Schedule a reboot at the specified time |
 | `ls [-l]` | List files on the remote path |
 | `show COMMAND [--retry N]` / `show -f FILE` | Run an arbitrary CLI command (or file of commands) across devices |
-| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight checks: NETCONF reachability, local/remote firmware hash |
+| `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight checks: NETCONF reachability, local/remote firmware checksum |
 | `config -f FILE` | Push a set command file (see [docs/config.md](docs/config.md) for `--confirm`, `--timeout`, `--no-confirm`, `--no-commit`, `--health-check`, `--no-health-check`) |
 | `rsi` | Collect RSI/SCF in parallel |
 | (none) | Show device facts |
@@ -475,7 +475,7 @@ rt1.example.jp: software validate package-result: 0
 
 ### check (pre-flight verification)
 
-Unified pre-flight checks across NETCONF reachability and firmware hashes. Exit code is non-zero if any check fails. Default (no flag) runs `--connect` only.
+Unified pre-flight checks across NETCONF reachability and firmware checksums. Exit code is non-zero if any check fails. Default (no flag) runs `--connect` only.
 
 `--local` is **inventory-mode** and ignores hostnames — it iterates every `<model>.file` / `<model>.hash` pair in `config.ini` and verifies the files on the staging server. No NETCONF required:
 

--- a/junos_ops/cli.py
+++ b/junos_ops/cli.py
@@ -580,7 +580,12 @@ def _check_local_inventory() -> list[dict]:
     exclude_tags = getattr(common.args, "exclude_tags", None)
 
     if filter_model:
-        models = [filter_model]
+        # iter_configured_models() yields lowercase names (configparser
+        # lowercases keys), and the firmware lookup is case-insensitive
+        # too. Normalize the --model value so the rendered model column
+        # matches the default listing instead of echoing the user's
+        # casing (e.g. EX2300-24T vs ex2300-24t for the same model).
+        models = [filter_model.lower()]
     else:
         models = upgrade.iter_configured_models()
 
@@ -856,7 +861,7 @@ def _run():
     p_check = subparsers.add_parser(
         "check",
         parents=[parent],
-        help="pre-flight checks (NETCONF reachability, local/remote firmware hash)",
+        help="pre-flight checks (NETCONF reachability, local/remote firmware checksum)",
     )
     p_check.add_argument(
         "--connect", dest="check_connect", action="store_true",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -272,7 +272,12 @@ class TestCheckLocalInventory:
         assert all(call.args[0] == "DEFAULT" for call in mock_chk.call_args_list)
 
     def test_model_filter(self, mock_config):
-        """--model X restricts inventory to the requested model only."""
+        """--model X restricts inventory to the requested model only.
+
+        The model name is normalized to lowercase so the rendered model
+        column matches the default listing (configparser lowercases keys
+        and the firmware lookup is case-insensitive).
+        """
         common.args = _make_check_args(check_local=True, check_model="EX2300-24T")
         with patch.object(
             junos_upgrade_mod,
@@ -280,8 +285,9 @@ class TestCheckLocalInventory:
             return_value={"status": "ok", "file": "pkg", "cached": False},
         ) as mock_chk:
             rows = cli._check_local_inventory()
-        mock_chk.assert_called_once_with("DEFAULT", "EX2300-24T")
+        mock_chk.assert_called_once_with("DEFAULT", "ex2300-24t")
         assert len(rows) == 1
+        assert rows[0]["model"] == "ex2300-24t"
 
 
 def _make_model_tags_config():
@@ -449,6 +455,20 @@ class TestCheckLocalInventoryModelTags:
             cli._check_local_inventory()
         models = sorted(c.args[1] for c in mock_chk.call_args_list)
         assert models == ["ex2300-24t", "ex3400-24t", "mx240", "srx345"]
+
+    def test_model_case_matches_default_listing(self, junos_common):
+        """--model EX2300-24T renders the same label as the default listing."""
+        common.config = _make_model_tags_config()
+        # Default listing label for this model.
+        common.args = _make_check_args(check_local=True)
+        with self._patched_check():
+            default_rows = cli._check_local_inventory()
+        default_label = next(r["model"] for r in default_rows if r["model"] == "ex2300-24t")
+        # Same model via uppercase --model must produce the identical label.
+        common.args = _make_check_args(check_local=True, check_model="EX2300-24T")
+        with self._patched_check():
+            model_rows = cli._check_local_inventory()
+        assert [r["model"] for r in model_rows] == [default_label]
 
 
 class TestCheckLocalInventoryFormat:


### PR DESCRIPTION
## Summary

Two small fixes that ride together to enable a 0.25.1 patch release.

### 1. `--model` casing inconsistency (the actual bug)

`check --local --model EX2300-24T` rendered the model column as `EX2300-24T` (echoing the user's casing), while the default listing showed `ex2300-24t` (configparser lowercases keys). The **same model** therefore appeared under two different labels depending on whether `--model` was passed.

```
$ junos-ops check --local --model EX2300-24T   ->  model: EX2300-24T
$ junos-ops check --local                       ->  model: ex2300-24t
```

The firmware lookup was already case-insensitive, so this is a **display-only** normalization: lowercase the `--model` value so both paths render identically.

### 2. Terminology: "firmware hash" -> "checksum"

Follow-through on #104 (table header `status` -> `checksum`). The `check` subcommand's one-line help and the README check descriptions still said "firmware hash", while the `--local`/`--remote` sub-flag help already said "checksum". Aligned them.

Config keys (`<model>.hash`, `hashalgo`) and the JSON dict fields (`actual_hash`, `expected_hash`) are a stable contract and are **left unchanged**.

## Test plan

- [x] `pytest tests/` — 361 passed
- [x] `test_model_filter` updated to assert the lowercased call + rendered label
- [x] New `test_model_case_matches_default_listing` regression guard (same model via `--model EX2300-24T` and default listing produce the identical label)
- [x] `junos-ops check --help` shows "firmware checksum"

🤖 Generated with [Claude Code](https://claude.com/claude-code)