### PR TITLE
docs: document snapshot subcommand and --rsi-dir option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ junos_ops/
 ├── common.py       # 共通機能（設定読込、接続管理、ターゲット決定、並列実行）
 ├── upgrade.py      # upgrade系機能（コピー、インストール、ロールバック、バージョン管理）
 ├── show.py         # show サブコマンド core（run_cli / run_cli_batch、text|json|xml）
-└── rsi.py          # RSI/SCF収集機能
+├── snapshot.py     # snapshot サブコマンド core（request system snapshot、代替メディア判定）
+├── rsi.py          # RSI/SCF収集機能
+└── display.py      # 表示層（core が返す dict を人間向け整形 / JSON シリアライズ）
 tests/
 ├── conftest.py     # pytest フィクスチャ
 ├── test_config.py  # 設定読込・モデル取得・ハッシュキャッシュのテスト
@@ -36,7 +38,15 @@ tests/
 ├── test_reboot.py      # reboot・config変更検出・snapshot削除のテスト
 ├── test_config_push.py # config サブコマンド（load_config）のテスト
 ├── test_show.py        # show サブコマンドのテスト
+├── test_snapshot.py    # snapshot サブコマンド（create_snapshot・代替メディア判定）のテスト
 ├── test_rsi.py     # RSI/SCF収集のテスト
+├── test_check.py       # check サブコマンド（local/remote/connect inventory）のテスト
+├── test_display.py     # display 層（format_*/print_*/JSON）のテスト
+├── test_install.py     # install フローのテスト
+├── test_unlink.py      # --unlink 経路（CLI 直接実行）のテスト
+├── test_json_output.py # --json JSONL 出力のテスト
+├── test_list_remote.py # ls サブコマンドのテスト
+├── test_package_checks.py # ローカル/リモート firmware checksum 検証のテスト
 └── test_cli_parse.py   # CLI引数パース・サブコマンドなし実行のテスト
 pyproject.toml      # パッケージメタデータ、エントリポイント
 config.ini          # 設定ファイル（設定例）
@@ -84,7 +94,7 @@ LICENSE
 - すべての core 関数は stdout に print しない。人間向け整形は `display` 層が担う。
 
 ### display.py — 表示層
-- `print_version()`, `print_copy()`, `print_install()`, `print_rollback()`, `print_reboot()`, `print_reinstall()`, `print_load_config()`, `print_list_remote()`, `print_dry_run()`, `print_rsi()`, `print_show()`, `print_connect_error()`, `print_read_config_error()`, `print_host_header()`, `print_host_footer()` — core が返す dict を人間向けに整形
+- `print_version()`, `print_copy()`, `print_install()`, `print_rollback()`, `print_reboot()`, `print_reinstall()`, `print_load_config()`, `print_list_remote()`, `print_dry_run()`, `print_rsi()`, `print_show()`, `print_snapshot()`, `print_connect_error()`, `print_read_config_error()`, `print_host_header()`, `print_host_footer()` — core が返す dict を人間向けに整形（`format_snapshot()` 等の `format_*` が整形ロジック本体）
 - `format_json(hostname, result)` / `print_json(hostname, result)` — core dict を `{"hostname": ..., **result}` の 1 行 JSON にシリアライズ（`--json` 用）。`format_json_obj(obj)` / `print_json_obj(obj)` は hostname を注入せず obj をそのまま出す（`check` の model 単位 row 用）。`json.dumps(..., default=str, ensure_ascii=False)` で lxml/datetime 等の非シリアライズ値も str fallback、非 ASCII はそのまま
 - `_print_lock` (`threading.Lock`) でマルチワーカー時の出力インターリーブを防止
 - junos-mcp など非 CLI 利用者は display を import しなければ stdout 出力ゼロ
@@ -96,6 +106,13 @@ LICENSE
 - `VALID_FORMATS` — `("text", "json", "xml")`
 - Caveat: NETCONF は `json` / `xml` 取得時に `| match` / `| last` / `| count` などのパイプ段を落とす。フィルタしたいときは `text` かつシェル側で加工
 
+### snapshot.py — snapshot サブコマンド core（すべて dict を返す）
+- 用途: `request system snapshot` で稼働中システム（root ＋ config）を**代替（バックアップ）ブートメディア**へ同期。アップグレードは稼働中メディアしか書き換えず代替面が「化石化」するため、フォールバック時の安全性を担保する。MX 中心
+- `create_snapshot(hostname, dev)` — core（dict: hostname/ok/dry_run/message/error/steps、no-op 時は `skipped` も）。`dev.facts["personality"]` で機種分類し、`_SNAPSHOT_RPC_ARGS` に無い personality（vmhost MX / mid-high SRX / HA / vMX/vSRX / Evolved / 不明）は **非致命的スキップ**。EX/QFX の out-of-space も `_is_out_of_space()` 判定で clean skip
+- `running_on_alternate_media(dev)` — 代替メディア稼働判定（`True`/`False`/`None`=判定不能）。ベストエフォート
+- **安全ガード:** 代替メディア稼働中（`on_alt is True`）かつ `--force` 無しなら `error="running_on_alternate_media"` で拒否（古いシステムをプライマリへ複製するのを防ぐ）。`None`（判定不能）は警告付きで続行
+- `_SNAPSHOT_RPC_ARGS` / `_SNAPSHOT_LABEL` — personality → RPC 引数・表示ラベルのマッピング（Branch SRX は `slice alternate`）
+
 ### rsi.py — RSI/SCF収集
 - RSI = request support information
 - SCF = show configuration | display set
@@ -105,7 +122,7 @@ LICENSE
 
 ### cli.py — サブコマンドルーティング
 - `main()` — argparse サブコマンド定義、ディスパッチ
-- `cmd_upgrade()`, `cmd_copy()`, `cmd_install()`, `cmd_rollback()`, `cmd_version()`, `cmd_reboot()`, `cmd_ls()`, `cmd_show()`, `cmd_config()`, `cmd_facts()` — サブコマンド用エントリ関数（connect → header → core(dict) → display）
+- `cmd_upgrade()`, `cmd_copy()`, `cmd_install()`, `cmd_rollback()`, `cmd_version()`, `cmd_reboot()`, `cmd_snapshot()`, `cmd_ls()`, `cmd_show()`, `cmd_config()`, `cmd_facts()` — サブコマンド用エントリ関数（connect → header → core(dict) → display）
 - `_check_host(hostname)` — `check` サブコマンド用ワーカー。int ではなく dict を返し、`main()` で結果を集約して `display.print_check_table` にテーブル出力。モデル解決順: `--model` > `config.ini [host].model` > `dev.facts["model"]`
 - `_check_local_inventory()` — `check --local` 用。`iter_configured_models()` の出力に対し `--model`（単一名）＋ `--tags` / `--exclude-tags`（`common._filter_models_by_tag_groups` で model 名 OR `<model>.tags` の OR フィルタ）を**積集合**で適用。`--local` 単独実行時 (`check_connect`/`check_remote` ともに false) は `_run()` 側で `get_targets()` をスキップさせ、ホスト側 `--tags` が "no hosts matched tags" で sys.exit するのを回避。フィルタ後 0 件は `logger.info` で「なぜ空か」をログる
 - `_open_connection()` — NETCONF 接続＋エラー時の display 出力ヘルパー（`--json` 時は connect エラーを JSON で出す）
@@ -121,11 +138,12 @@ junos-ops install [hostname ...]           # インストールだけ
 junos-ops rollback [hostname ...]          # ロールバック
 junos-ops version [hostname ...]           # バージョン表示
 junos-ops reboot --at YYMMDDHHMM [hostname ...]  # リブート
+junos-ops snapshot [--force] [hostname ...] # 代替ブートメディアを同期（request system snapshot、MX中心）
 junos-ops ls [-l] [hostname ...]           # リモートファイル一覧
 junos-ops show COMMAND [-F text|json|xml] [hostname ...]   # 任意の CLI コマンドを実行（-F で構造化出力）
 junos-ops config -f FILE [--confirm N] [hostname ...]  # set コマンドファイル適用
 junos-ops check [--connect|--local|--remote|--all] [--model M] [hostname ...]  # pre-flight チェック
-junos-ops rsi [hostname ...]               # RSI/SCF収集
+junos-ops rsi [--rsi-dir DIR] [hostname ...]  # RSI/SCF収集（--rsi-dir で出力先を上書き）
 junos-ops [hostname ...]                   # サブコマンド省略 → device facts 表示
 junos-ops --version                        # プログラムバージョン
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,7 @@ Juniper/JUNOS デバイスの運用を NETCONF 経由で自動化する Python C
 - インストール前のパッケージ検証（validate）
 - ロールバック対応（MX/EX/SRX モデル別処理）
 - スケジュールリブート（ファームウェアインストール後の config 変更を自動検出し、必要なら再インストール）
+- オンデマンドのリカバリスナップショット（`snapshot`）で代替ブートメディアを同期（MX 中心）、代替メディア稼働時の安全ガード付き
 - RSI（request support information）/ SCF（show configuration | display set）の並列収集
 - Pre-flight `check` サブコマンド: NETCONF 疎通・ローカル firmware チェックサム（デバイス接続不要）・リモート firmware チェックサムを 1 コマンドで統合表示
 - 任意の CLI コマンドを複数ホストで実行（`show` サブコマンド、`RpcTimeoutError` 自動リトライ対応）
@@ -205,6 +206,7 @@ junos-ops <subcommand> [options] [hostname ...]
 | `rollback` | 前バージョンにロールバック |
 | `version` | running/planning/pendingバージョンとリブート予定を表示 |
 | `reboot --at YYMMDDHHMM` | 指定日時にリブートをスケジュール |
+| `snapshot [--force]` | リカバリスナップショット（`request system snapshot`）を作成し代替ブートメディアを同期。MX 中心。代替メディアで稼働中のデバイスでは `--force` がない限り拒否。詳細は後述の [snapshot](#snapshotブートメディアの代替面を同期) を参照 |
 | `ls [-l]` | リモートパスのファイル一覧 |
 | `show COMMAND [--retry N]` / `show -f FILE` | 任意の CLI コマンド（またはコマンドファイル）を複数ホストで実行 |
 | `check [--connect\|--local\|--remote\|--all] [--model M]` | Pre-flight チェック: NETCONF 疎通・ローカル/リモート firmware チェックサム |
@@ -527,6 +529,8 @@ rt2.example.jp   ok       missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.t
   rt2.example.jp.RSI done
 ```
 
+出力先は config.ini の `RSI_DIR` で指定しますが、`--rsi-dir DIR` で実行ごとに上書きできます（デフォルト: カレントディレクトリ）。
+
 ### reboot（スケジュールリブート）
 
 ```
@@ -534,6 +538,25 @@ rt2.example.jp   ok       missing     MX5-T     jinstall-ppc-18.4R3-S10-signed.t
 # rt1.example.jp
 	Shutdown at Fri Jun 13 05:00:00 2025. [pid 97978]
 ```
+
+### snapshot（ブートメディアの代替面を同期）
+
+```
+% junos-ops snapshot rt1.example.jp
+# rt1.example.jp
+	snapshot: 'request system snapshot' completed
+```
+
+`request system snapshot` を実行し、稼働中システム（root ＋ config）を**代替（バックアップ）ブートメディア**へコピーします。
+
+JUNOS のアップグレードは現在稼働中のメディアしか書き換えず、代替面は自動更新されないため時間とともに古くなります（「化石化した代替面」）。後にプライマリがブートに失敗すると、デバイスはその古い代替面にフォールバックし、疎通できない状態で立ち上がることがあります。リスクの高い変更の前や定期的にスナップショットを取っておくと、代替面が最新に保たれフォールバックが安全になります。
+
+- **MX が主対象**（固定構成の MX5/MX80 デュアル eUSB、および RE/ディスクベースの MX240/480）。この問題が実際に表面化するプラットフォームです。
+- **EX/QFX（SWITCH）** は対応していますが、EX2300/EX3400 は慢性的に空き容量が逼迫しておりリカバリスナップショットが収まらない場合があります。容量不足は致命的エラーではなく、クリーンな「スキップ」として報告されます。
+- **Branch SRX（SRX300/320/340/345/380）** は対応していますが**優先度は低め**です。通常のアップグレード時に代替スライスが同期されるため、明示的なスナップショットは通常不要です（`request system snapshot slice alternate` を使用）。
+- その他のプラットフォーム（MX204/MX10003 等の vmhost MX、mid/high-end SRX、HA クラスタ、vMX/vSRX、Junos Evolved、不明機種）は**スキップ**されます（非致命的）。スナップショット挙動が未検証のハードウェアにはコマンドを発行しません。
+
+**安全ガード:** `snapshot` は、代替メディアで稼働中と判定されるデバイス上では実行を拒否します（古い可能性のあるシステムをプライマリへ複製してしまうのを防ぐため）。稼働中イメージこそ伝播させたいものだと確信できる場合のみ `--force` で上書きしてください。代替メディア稼働状態のオンデバイス判定はベストエフォートで、「判定不能（inconclusive）」を報告することがあります（その場合は警告付きでスナップショットを続行します）。
 
 ### config（set コマンドファイル適用）
 

--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ When `--connect` / `--remote` need to resolve a model and it was not supplied vi
   rt2.example.jp.RSI done
 ```
 
+The output directory comes from `RSI_DIR` in config.ini, but `--rsi-dir DIR` overrides it per run (default: current directory).
+
 ### reboot (scheduled reboot)
 
 ```


### PR DESCRIPTION
## 概要

実装済み機能とドキュメントの突き合わせ監査で見つかったギャップを修正します。

`snapshot` サブコマンド（#108）は **README.md（英語）には記載済み**でしたが、**README.ja.md（日本語）には完全欠落**し、**CLAUDE.md にも未反映**でした。また `--rsi-dir` CLI フラグは3ドキュメントすべてで未記載でした。

## 監査方法

`junos_ops/cli.py` の argparse 定義（12サブコマンド＋全オプション）を「正」として README 両言語・CLAUDE.md と突き合わせ。他の新機能オプション（`--unlink` / `--exclude-tags` / `--json` / `--no-commit` / `--no-confirm` / `--no-health-check` / `--retry` / `--workers` / `--model` / `--health-check`）は英日とも記載済みで問題なしと確認。

## 変更内容

- **README.ja.md**: snapshot を機能リスト・コマンド表・専用セクション（README.md の英語版に対応する日本語）に追加。rsi セクションに `--rsi-dir` を追記
- **README.md**: rsi セクションに `--rsi-dir` を追記
- **CLAUDE.md**: ファイルツリーに `snapshot.py` / `display.py` と欠落していたテストファイルを追加、snapshot.py モジュール節を追加、`cmd_snapshot` / `print_snapshot` を一覧に追記、CLI設計ブロックに snapshot ＋ `--rsi-dir` を追加

ドキュメントのみの変更（`docs:`）。コード・テストの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)