### PR TITLE
docs(ja): fix broken Jinja2 template link in README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@ Juniper/JUNOS デバイスの運用を NETCONF 経由で自動化する Python C
 - Pre-flight `check` サブコマンド: NETCONF 疎通・ローカル firmware チェックサム（デバイス接続不要）・リモート firmware チェックサムを 1 コマンドで統合表示
 - 任意の CLI コマンドを複数ホストで実行（`show` サブコマンド、`RpcTimeoutError` 自動リトライ対応）
 - `config` での設定投入（commit confirmed + コミット後ヘルスチェック: ping / `uptime` NETCONF プローブ / 任意の CLI コマンド）
-- Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.md#日本語版)）
+- Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.ja.md)）
 - `--tags` によるタグベースのホストフィルタ（AND マッチ）
 - ローカルファームウェア置き場（`lpath`、`~` 展開対応）
 - ドライランモード（`--dry-run`）で事前確認


### PR DESCRIPTION
## 概要

README.ja.md L25 の Jinja2 テンプレートへのリンクが壊れていたので修正します。

```diff
-- Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.md#日本語版)）
+- Jinja2 テンプレートによるホスト別設定生成（[詳細](docs/template.ja.md)）
```

## 問題

`docs/template.md` は英語専用ドキュメントで `日本語版` という見出しを持たないため、アンカー `#日本語版` は解決せず、クリックしても英語版の先頭に飛ぶだけでした。日本語版 `docs/template.ja.md` は実在するので、そちらを指すよう修正します。

同ファイル L608 の詳細セクションへのリンクは元から `docs/template.ja.md` で正しく、今回の L25 のみが誤りでした。他に同種の誤リンク（日本語 README から英語アンカーへの参照）がないことも確認済みです。

ドキュメントのみの変更（`docs:`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)