### PR TITLE
docs: fix reboot code/logger/stdout claims, document config safety flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,12 +40,21 @@ dev loop above.
 ### 1. The `display`-import boundary (do not regress)
 
 Core modules (`upgrade.py`, `common.py`, `rsi.py`, `show.py`, `snapshot.py`)
-never write to stdout — they only return dicts. `display.py` is the *sole*
-place that prints. Its own docstring states the reason explicitly: non-CLI
-callers (i.e. the downstream MCP wrapper) use `display.format_*()` to render
-result dicts as strings, precisely so they never need to import or trigger
-anything that writes to stdout. As long as that wrapper never imports
-`display`, it emits zero stdout output.
+return dicts and, on the normal path, do not write to stdout — `display.py`
+is the *sole* place that prints. (The one deliberate exception is
+`common.get_targets()`'s inner `_fatal()`, which prints a diagnostic to
+`sys.stdout` when `--json` is not set and then `sys.exit(1)`; a library caller
+that passes an empty host selection can hit it. Don't take that as licence to
+add new stdout writes elsewhere in core modules.) Its own docstring states the
+reason explicitly: non-CLI callers (i.e. the downstream MCP wrapper) use
+`display.format_*()` to render result dicts as strings, precisely so they
+never need to import or trigger anything that writes to stdout. As long as
+that wrapper never imports `display`, it emits zero stdout output.
+
+Relatedly, `argcomplete` (`cli.py`) and `tqdm` (in `_run_check_with_progress`)
+are imported under `try/except ImportError` on purpose — they map to the
+optional `completion` / `progress` extras, so a diff that moves either to a
+module-level `import` would break the default (extras-free) install. Flag it.
 
 This means: any stray `print()`/debug statement added to a core module, or
 any refactor that makes `display` get imported transitively by something the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ LICENSE
 - `copy()` — SCP転送＋チェックサム検証（dict: storage_cleanup/snapshot_delete/steps/error）
 - `install()` — パッケージインストール（dict: copy_result/rollback_result/rescue_save/steps など nested）
 - `rollback()` — 前バージョンへの復帰（dict: ok/rpc_output/message/error）
-- `reboot()` — スケジュールリブート（dict: code/reinstall_result/steps。code は従来の 0..6 を保持）
+- `reboot()` — スケジュールリブート（dict: code/reinstall_result/steps。code は 0..7。7 は `--force` 無しで `get-reboot-information` の XML 解析に失敗したケース、issue #60）
 - `show_version()` — バージョン情報収集（dict: running/planning/pending/commit/config_changed_after_install 他）
 - `get_model_file()` / `get_model_hash()` — モデル→パッケージマッピング
 - `get_pending_version()` / `get_planning_version()` / `compare_version()` — バージョン比較
@@ -88,7 +88,7 @@ LICENSE
 - `check_remote_package(hostname, dev)` / `check_remote_package_by_model(hostname, dev, model)` — リモート firmware checksum 検証（by_model 版はモデルを明示指定）
 - `_compute_local_checksum(path, algo)` — hashlib ベースの純粋関数（PyEZ SW 非依存）
 - `get_hashcache()` / `set_hashcache()` / `clear_hashcache()` — チェックサムキャッシュ（スレッド安全）。`clear_hashcache` は `storage_cleanup` 後に invoke して cache が stale 化するのを防ぐ
-- `load_config()` — set コマンドファイルのロード＋コミット（dict: steps + logger.info でリアルタイム進捗）
+- `load_config()` — set/Jinja2(`.j2`) 設定ファイルのロード＋コミット（dict: steps/template/rendered_commands/diff/commit_mode 等。各ステップを `logger.debug` で実時間エコー、関数自身は print しない）。フローは lock → load → diff → commit_check → **commit confirmed** → ヘルスチェック → confirm → unlock。**ヘルスチェック失敗時は commit を confirm せず**、JUNOS の commit-confirmed タイマー満了で**自動ロールバック**させる（リモート機を締め出さない生命線。この順序は load-bearing）。`.j2` の場合は `common.render_template()` が config.ini ホストセクションの `var_` 変数＋`facts`/`hostname` を StrictUndefined でレンダリング（optional extra `junos-ops[template]` が必要）
 - `list_remote_path()` — リモートファイル一覧（dict: files/file_count/format）
 - `dry_run()` — local/remote package の検証（dict）
 - すべての core 関数は stdout に print しない。人間向け整形は `display` 層が担う。
@@ -141,7 +141,7 @@ junos-ops reboot --at YYMMDDHHMM [hostname ...]  # リブート
 junos-ops snapshot [--force] [hostname ...] # 代替ブートメディアを同期（request system snapshot、MX中心）
 junos-ops ls [-l] [hostname ...]           # リモートファイル一覧
 junos-ops show COMMAND [-F text|json|xml] [hostname ...]   # 任意の CLI コマンドを実行（-F で構造化出力）
-junos-ops config -f FILE [--confirm N] [hostname ...]  # set コマンドファイル適用
+junos-ops config -f FILE [--confirm N] [--health-check CMD ...] [--no-health-check] [--no-confirm] [--no-commit] [hostname ...]  # set/.j2 設定ファイル適用（commit confirmed＋ヘルスチェック＋自動ロールバック）
 junos-ops check [--connect|--local|--remote|--all] [--model M] [hostname ...]  # pre-flight チェック
 junos-ops rsi [--rsi-dir DIR] [hostname ...]  # RSI/SCF収集（--rsi-dir で出力先を上書き）
 junos-ops [hostname ...]                   # サブコマンド省略 → device facts 表示
@@ -220,7 +220,7 @@ CI で sdist / wheel のビルドを検証。pyproject.toml の記述ミス（PE
 1. Conventional Commits（`feat:` / `fix:` / `refactor:` / `perf:` など）で main にマージする
 2. release-please が自動で "chore(release): ..." の PR を開き、次バージョン候補と CHANGELOG を提示する
 3. 内容を確認して PR をマージ → release-please がタグ (`v0.X.Y`) と GitHub Release を作成
-4. `release.yml` が `release: published` で発火 → TestPyPI → PyPI → homebrew-tap 通知まで自動実行
+4. `release: published` で `release.yml`（TestPyPI → PyPI → homebrew-tap 通知）に加え `deb.yml` / `rpm.yml`（.deb / .rpm ビルド＋当該 Release へ添付）が発火
 
 `junos_ops/__init__.py` の `__version__` には `# x-release-please-version` マーカーが付いており、release-please が `.release-please-manifest.json` と同期して書き換える。CHANGELOG.md も自動 prepend される。
 
@@ -229,7 +229,8 @@ CI で sdist / wheel のビルドを検証。pyproject.toml の記述ミス（PE
 - `release-please-config.json` — package-name、release-type（python）、extra-files、changelog-sections
 - `.release-please-manifest.json` — 現在のバージョン（release-please が更新）
 - `.github/workflows/release-please.yml` — push: main で発火、`RELEASE_PLEASE_TOKEN`（fine-grained PAT）で下流 workflow を起動
-- `.github/workflows/release.yml` — `release: published` をフック、PyPI 公開と homebrew-tap 通知
+- `.github/workflows/release.yml` — `release: published` をフック、TestPyPI → PyPI 公開と homebrew-tap 通知
+- `.github/workflows/deb.yml` / `rpm.yml` — 同じく `release: published`（＋ `workflow_dispatch`）で発火し .deb / .rpm をビルドして当該 Release に添付（パッケージング設定は `debian/` / `rpm/` ディレクトリ）
 
 ### 下流連携
 


### PR DESCRIPTION
## What

Fixes drift a Fable5 audit found between the guidance docs and the current code. Docs only.

### Inaccuracies corrected
- **reboot() code range** — CLAUDE.md said "0..6"; `upgrade.py:1844` assigns `code = 7` (get-reboot-information XML parse failure without `--force`, issue #60). The docstring documents 0..7.
- **load_config() log level** — CLAUDE.md said `logger.info`; the code echoes each step via `logger.debug` (`upgrade.py:2118`) and does not print itself.
- **"never write to stdout"** (copilot §1) — `common.get_targets()`'s `_fatal()` prints to `sys.stdout` when `--json` is unset, then `sys.exit(1)` (`common.py:268`). Reworded to name that one deliberate exception rather than an absolute "never".

### Omissions added (verified against the tree)
- **config commit-confirmed safety flow** — lock → load → diff → commit_check → commit confirmed → health check → confirm → unlock; a failed health check is deliberately left **unconfirmed** so JUNOS auto-rolls back (the lifeline that stops a bad push from locking out a remote router). Plus `--health-check` / `--no-health-check` / `--no-confirm` / `--no-commit` in the CLI synopsis.
- **Jinja2 `.j2` template push** — `common.render_template()`, `var_`-prefixed config.ini vars, `StrictUndefined`, the optional `junos-ops[template]` extra.
- **deb.yml / rpm.yml** also fire on `release: published` (packaging in `debian/` and `rpm/`).
- The deliberate **soft-import** pattern for `argcomplete` / `tqdm` (optional `completion`/`progress` extras).

## Scope

**Do not merge yet** — part of a batch of doc-audit PRs held for review.