### PR TITLE
chore: add dependabot.yml (pip + github-actions, monthly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      runtime-dependencies:
+        dependency-type: production
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies


### PR DESCRIPTION
Adds Dependabot version updates (monthly) for pip and github-actions ecosystems, matching the configuration used across the other shigechika repositories (jquants-mcp et al.). Part of a security-configuration audit across all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)