### PR TITLE
ci: attach release assets to a draft, then publish (immutable-ready)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,8 +1,16 @@
 name: Build .deb packages
 
+# Called from release-please.yml while the release is still a DRAFT so the
+# assets are attached before publishing (required for immutable releases —
+# assets cannot be added after publish). workflow_dispatch remains for
+# ad-hoc builds and uploads nothing.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Draft release tag to attach the .deb to (e.g. v0.20.0)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -43,11 +51,14 @@ jobs:
             libffi-dev
 
       - name: Update debian/changelog version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           else
-            VERSION="${GITHUB_REF_NAME#v}"
+            VERSION="${INPUT_TAG#v}"
           fi
           sed -i "1s/([^)]*)/($VERSION-1)/" debian/changelog
 
@@ -68,9 +79,12 @@ jobs:
           path: junos-ops_*~${{ matrix.codename }}.deb
           retention-days: 7
 
+      # The release is still a draft at this point; gh resolves draft
+      # releases by tag name for users with push access.
       - name: Upload .deb to GitHub Release
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" junos-ops_*~${{ matrix.codename }}.deb --clobber
+          gh release upload "$TAG" junos-ops_*~${{ matrix.codename }}.deb --clobber

--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -11,6 +11,10 @@ on:
         description: "Draft release tag to attach the .deb to (e.g. v0.20.0)"
         required: true
         type: string
+      sha:
+        description: "Commit to build from (the draft release's target)"
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -29,9 +33,13 @@ jobs:
       contents: write
 
     steps:
+      # Build the exact commit the draft release targets, not whatever HEAD
+      # the calling run happens to sit on (empty on workflow_dispatch →
+      # default checkout).
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.sha }}
 
       - name: Install build dependencies
         run: |
@@ -78,6 +86,9 @@ jobs:
           name: junos-ops-${{ matrix.codename }}
           path: junos-ops_*~${{ matrix.codename }}.deb
           retention-days: 7
+          # Without this, re-running a failed job 409s on the artifact left
+          # by the previous attempt before ever reaching the release upload.
+          overwrite: true
 
       # The release is still a draft at this point; gh resolves draft
       # releases by tag name for users with push access.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,11 +9,26 @@ permissions:
   contents: write
   pull-requests: write
 
+# Release flow (immutable-releases compatible):
+#   1. release-please creates the GitHub Release as a DRAFT ("draft": true in
+#      release-please-config.json). A draft has no git tag yet.
+#   2. deb/rpm build against the merged commit (which contains the version
+#      bump) and attach their packages to the draft.
+#   3. publish-release flips the draft to published — that creates the tag
+#      and fires release:published, which triggers the PyPI pipeline
+#      (release.yml) exactly as before.
+# Assets must be attached BEFORE publishing: with immutable releases enabled,
+# a published release's assets can never be added, changed, or removed.
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           # Use a fine-grained PAT so that tags and releases created by
           # release-please trigger downstream workflows. Tokens attributed
@@ -28,3 +43,32 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  deb:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/deb.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+
+  rpm:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/rpm.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: [release-please, deb, rpm]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # Publish with the PAT for the same recursion-guard reason as above:
+      # publishing is what creates the tag and emits release:published, and
+      # that event must be allowed to trigger release.yml.
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$TAG" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Never run two release pipelines at once: with draft releases a lost race
+# would create two drafts for the same tag (release-please's "already
+# released" check is label-based and happens after release creation).
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 # Release flow (immutable-releases compatible):
 #   1. release-please creates the GitHub Release as a DRAFT ("draft": true in
 #      release-please-config.json). A draft has no git tag yet.
@@ -26,6 +33,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -50,6 +58,7 @@ jobs:
     uses: ./.github/workflows/deb.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}
 
   rpm:
     needs: release-please
@@ -57,6 +66,7 @@ jobs:
     uses: ./.github/workflows/rpm.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}
 
   publish-release:
     needs: [release-please, deb, rpm]

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -11,6 +11,10 @@ on:
         description: "Draft release tag to attach the .rpm to (e.g. v0.20.0)"
         required: true
         type: string
+      sha:
+        description: "Commit to build from (the draft release's target)"
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -27,9 +31,13 @@ jobs:
       GH_REPO: ${{ github.repository }}
 
     steps:
+      # Build the exact commit the draft release targets, not whatever HEAD
+      # the calling run happens to sit on (empty on workflow_dispatch →
+      # default checkout).
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.sha }}
 
       - name: Install build dependencies
         run: |
@@ -99,6 +107,9 @@ jobs:
           name: junos-ops-el9
           path: "${{ github.workspace }}/*.rpm"
           retention-days: 7
+          # Without this, re-running a failed job 409s on the artifact left
+          # by the previous attempt before ever reaching the release upload.
+          overwrite: true
 
       # The release is still a draft at this point; gh resolves draft
       # releases by tag name for users with push access.

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,8 +1,16 @@
 name: Build .rpm packages
 
+# Called from release-please.yml while the release is still a DRAFT so the
+# assets are attached before publishing (required for immutable releases —
+# assets cannot be added after publish). workflow_dispatch remains for
+# ad-hoc builds and uploads nothing.
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Draft release tag to attach the .rpm to (e.g. v0.20.0)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -42,11 +50,14 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+            echo "version=${INPUT_TAG#v}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build virtualenv
@@ -89,9 +100,12 @@ jobs:
           path: "${{ github.workspace }}/*.rpm"
           retention-days: 7
 
+      # The release is still a draft at this point; gh resolves draft
+      # releases by tag name for users with push access.
       - name: Upload .rpm to GitHub Release
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" *.rpm --clobber
+          gh release upload "$TAG" ./*.rpm --clobber

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,11 @@ CI で sdist / wheel のビルドを検証。pyproject.toml の記述ミス（PE
 
 1. Conventional Commits（`feat:` / `fix:` / `refactor:` / `perf:` など）で main にマージする
 2. release-please が自動で "chore(release): ..." の PR を開き、次バージョン候補と CHANGELOG を提示する
-3. 内容を確認して PR をマージ → release-please がタグ (`v0.X.Y`) と GitHub Release を作成
-4. `release: published` で `release.yml`（TestPyPI → PyPI → homebrew-tap 通知）に加え `deb.yml` / `rpm.yml`（.deb / .rpm ビルド＋当該 Release へ添付）が発火
+3. 内容を確認して PR をマージ → release-please が GitHub Release を **draft** で作成（この時点ではタグ無し）
+4. 同じ `release-please.yml` 内で `deb.yml` / `rpm.yml` が reusable workflow として呼ばれ、.deb / .rpm を draft Release に添付
+5. 添付完了後に `publish-release` ジョブが draft を公開 → タグ (`v0.X.Y`) が作成され、`release: published` で `release.yml`（TestPyPI → PyPI → homebrew-tap 通知）が発火
+
+draft → 添付 → 公開の順序は **Immutable Releases** 対応のため（公開後は資産の追加・変更・削除が一切できない）。
 
 `junos_ops/__init__.py` の `__version__` には `# x-release-please-version` マーカーが付いており、release-please が `.release-please-manifest.json` と同期して書き換える。CHANGELOG.md も自動 prepend される。
 
@@ -228,9 +231,9 @@ CI で sdist / wheel のビルドを検証。pyproject.toml の記述ミス（PE
 
 - `release-please-config.json` — package-name、release-type（python）、extra-files、changelog-sections
 - `.release-please-manifest.json` — 現在のバージョン（release-please が更新）
-- `.github/workflows/release-please.yml` — push: main で発火、`RELEASE_PLEASE_TOKEN`（fine-grained PAT）で下流 workflow を起動
+- `.github/workflows/release-please.yml` — push: main で発火。draft Release 作成 → deb/rpm 呼び出し → draft 公開までをオーケストレーション。`RELEASE_PLEASE_TOKEN`（fine-grained PAT）で Release を作成・公開し、下流 workflow を起動
 - `.github/workflows/release.yml` — `release: published` をフック、TestPyPI → PyPI 公開と homebrew-tap 通知
-- `.github/workflows/deb.yml` / `rpm.yml` — 同じく `release: published`（＋ `workflow_dispatch`）で発火し .deb / .rpm をビルドして当該 Release に添付（パッケージング設定は `debian/` / `rpm/` ディレクトリ）
+- `.github/workflows/deb.yml` / `rpm.yml` — `release-please.yml` から `workflow_call`（tag 入力）で呼ばれ .deb / .rpm をビルドして draft Release に添付。単発ビルドは `workflow_dispatch`（添付なし）。パッケージング設定は `debian/` / `rpm/` ディレクトリ
 
 ### 下流連携
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,8 @@ CI で sdist / wheel のビルドを検証。pyproject.toml の記述ミス（PE
 
 draft → 添付 → 公開の順序は **Immutable Releases** 対応のため（公開後は資産の追加・変更・削除が一切できない）。
 
+**deb/rpm 失敗時の復旧**: 同じ run の **「Re-run failed jobs」** で再開する（draft への `--clobber` 再アップロードは冪等）。**「Re-run all jobs」は使わない** — release-please がリリース済みと判定して全ジョブ skip となり、draft が未公開のまま残る。座礁した draft の手動復旧は `gh release upload <tag> <資産>` → PAT（`RELEASE_PLEASE_TOKEN` 相当）で `gh release edit <tag> --draft=false`（`GITHUB_TOKEN` で公開すると release.yml が発火しない）。
+
 `junos_ops/__init__.py` の `__version__` には `# x-release-please-version` マーカーが付いており、release-please が `.release-please-manifest.json` と同期して書き換える。CHANGELOG.md も自動 prepend される。
 
 ### 設定ファイル

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "python",
       "package-name": "junos-ops",
       "include-component-in-tag": false,
+      "draft": true,
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

Restructure the release flow to **draft → attach assets → publish** so that
[Immutable Releases](https://github.blog/changelog/2025-10-28-immutable-releases-are-now-generally-available/)
can be enabled on this repository. Today the .deb/.rpm assets are uploaded
*after* the release is published (`release: published` → `gh release upload`),
which immutability forbids — an immutable release's assets can never be added,
changed, or removed after publish.

## New flow (all inside release-please.yml)

1. release-please creates the GitHub Release as a **draft**
   (`"draft": true` in release-please-config.json). A draft has no git tag yet.
2. `deb.yml` / `rpm.yml` are invoked as **reusable workflows** (`workflow_call`
   with `tag` / `sha` inputs), build the draft's target commit (which contains
   the version bump), and attach their packages to the draft.
3. A final `publish-release` job flips the draft to published with
   `gh release edit "$TAG" --draft=false` using `RELEASE_PLEASE_TOKEN` —
   publishing creates the tag and fires `release: published`, which triggers
   the PyPI pipeline (release.yml) **unchanged**.

## Changes

- `release-please-config.json` — add `"draft": true`
- `release-please.yml` — orchestrates draft → deb/rpm → publish; exposes
  `release_created` / `tag_name` / `sha` outputs; `concurrency` group so two
  racing runs can't create duplicate drafts for the same tag
- `deb.yml` / `rpm.yml` — `release:` trigger replaced by `workflow_call`
  (a post-publish run would fail against an immutable release);
  `workflow_dispatch` kept for ad-hoc builds (uploads nothing);
  checkout pinned to the draft's target commit; upload targets the draft by
  tag (`gh` resolves draft releases by tag name for users with push access)
- `CLAUDE.md` — release-flow documentation + failure-recovery runbook

## Review

CI is green (actionlint + shellcheck where configured). Copilot review is
unavailable this month (credits exhausted), so an adversarial multi-agent
review was run instead; all its findings are folded into the second commit:

- artifact `overwrite: true` (junos-ops only — re-running a failed job
  otherwise 409s on the previous attempt's artifact)
- `concurrency` group on the release pipeline (duplicate-draft race)
- build pinned to the draft's target `sha` (was: the calling run's HEAD)
- recovery runbook: use **"Re-run failed jobs"**; "Re-run all jobs" makes
  release-please report nothing-to-do and strands the draft unpublished
  (manual recovery: `gh release upload` + `gh release edit --draft=false`
  with the PAT)

## Notes / edge cases

- The PAT requirement is unchanged: `RELEASE_PLEASE_TOKEN` is now also used by
  `publish-release`, because a release published by the default `GITHUB_TOKEN`
  would not trigger release.yml (recursion-prevention rule). Without the
  secret the behavior degrades exactly as before (release exists, PyPI job
  must be dispatched manually).
- If a deb/rpm build fails, the release stays draft (nothing published,
  no tag). Uploads use `--clobber`, safe while the release is still a draft.
- After merge, Immutable Releases will be enabled on this repo
  (`gh api -X PUT repos/{owner}/{repo}/immutable-releases`); the next
  release-please release exercises the new path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GziLteeQMYroRGPca5uCd3
