### PR TITLE
chore: release 0.26.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,11 +29,13 @@ pytest tests/ -v --tb=short
 pip install build && python -m build
 ```
 
-This mirrors `.github/workflows/ci.yml` (Python 3.12/3.13 matrix). CI also
-has separate `deb.yml`/`rpm.yml` jobs that package the sdist/wheel into
-`.deb`/`.rpm`; a PR that changes `pyproject.toml` packaging metadata should
-be checked against those workflows too, but they are not part of the normal
-dev loop above.
+This mirrors `.github/workflows/ci.yml` (Python 3.12/3.13 matrix). Separate
+`deb.yml`/`rpm.yml` workflows package the sdist/wheel into `.deb`/`.rpm` —
+they run inside the release pipeline (called from `release-please.yml`, which
+attaches the packages to a draft release before publishing) or ad hoc via
+`workflow_dispatch`. A PR that changes `pyproject.toml` packaging metadata
+should be checked against those workflows too, but they are not part of the
+normal dev loop above.
 
 ## Review focus
 


### PR DESCRIPTION
Forces a patch release (`Release-As: 0.26.1`) to exercise the new draft → attach → publish release pipeline (#123) end-to-end for the first time, and updates the Copilot review instructions to reflect it. The release ships the documentation fixes accumulated since v0.26.0 (#112, #116, #117).

Merge note: squash with the `Release-As: 0.26.1` footer preserved in the commit body so release-please picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GziLteeQMYroRGPca5uCd3