### PR TITLE
chore(deps): bump dependabot/fetch-metadata from v2 to v3

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
 
       - name: Enable auto-merge for patch/minor
         if: >-


### PR DESCRIPTION
Bumps `dependabot/fetch-metadata` from v2 to v3 in the Dependabot automerge
workflow.

The only breaking change in v3 is that the action now runs on the Node.js 24
Actions runtime, which GitHub-hosted `ubuntu-latest` provides.

This workflow consumes exactly one output, `steps.meta.outputs.update-type`,
which v3 does not change. Seven sibling repositories already run v3 with a
byte-identical copy of this workflow — diffing one of them against this file
shows the version string as the only difference — so the upgrade is already
proven on the same usage rather than merely expected to work.

Dependabot opened this bump elsewhere but not here; this catches the repository
up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVg3toYKK6J2J9ggdrzYVf