### PR TITLE
ci: always write the AI review in English

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -107,8 +107,10 @@ jobs:
           test suite would catch. For each finding cite the file and the
           diff hunk it occurs in, and briefly give the concrete failure
           scenario. If you find nothing significant, say so in one short
-          paragraph — do not invent findings. Respond in the primary
-          language of the PR description. Keep the review under 500 words.'
+          paragraph — do not invent findings. Write the review in English,
+          whatever language the PR description is in: this is a public
+          repository and the review is published with it. Keep the review
+          under 500 words.'
 
           jq -n --arg model "$MODEL" --arg system "$system" \
                 --rawfile user prompt.txt \


### PR DESCRIPTION
The prompt told the model to respond in the primary language of the PR
description, so a PR written in another language produced a review in that
language — published on a public repository where every other artifact is
English.

Pin the output language instead of inferring it. The description can stay in
whatever language the author prefers; the review that gets published does not
follow it.

The other repositories running this workflow were pinned earlier. This one was
missed at the time, so the behaviour is still live here.

No change beyond the prompt string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVg3toYKK6J2J9ggdrzYVf