### PR TITLE
feat: add pr-gate.yml admission control caller

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,17 @@
+name: PR Gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    uses: shigechika/ai-review/.github/workflows/pr-gate.yml@v1


### PR DESCRIPTION
Adds the optional `pr-gate.yml` caller from
[shigechika/ai-review](https://github.com/shigechika/ai-review#quick-start).

## Summary
- Closes pull requests from authors who are not a maintainer, member, or
  collaborator (`author_association`), with a canned explanatory comment.
- Adds the `ai-review` label to admitted PRs.
- Independent of `ai-review.yml` — this does not change how or when
  reviews run; fork PRs already get no secrets under the default
  GitHub policy either way.
- Set repository variable `AI_REVIEW_DISABLE_GATE` to `true` to make
  this workflow a no-op without removing the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)