### PR TITLE
fix: add explicit workflow permissions to ci.yml and release.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes 5 open CodeQL `actions/missing-workflow-permissions` alerts by
adding a workflow-level `permissions: contents: read` to `ci.yml` and
`release.yml`. No job needs a broader grant: `testpypi`/`publish`
already scope down to `id-token: write` and don't check out code.

Verified effective per-job permissions by parsing both workflow files —
every job that checks out code retains `contents: read`, and both OIDC
jobs retain `id-token: write`.

```
ci.yml
  lint            checkout=True  effective={'contents': 'read'}
  test            checkout=True  effective={'contents': 'read'}

release.yml
  verify          checkout=True  effective={'contents': 'read'}
  build           checkout=True  effective={'contents': 'read'}
  testpypi        checkout=False effective={'id-token': 'write'}
  publish         checkout=False effective={'id-token': 'write'}
  notify-homebrew checkout=False effective={'contents': 'read'}
```

Same fix already applied and verified in production on shigechika/mcp-stdio#407.

## Test plan

- [x] Verified effective permissions per job via script (above).
- [ ] CI passes on this PR.

Closes alerts #7, #6, #5, #4, #1 (`actions/missing-workflow-permissions`).
